### PR TITLE
Feilhåndtering

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -3,21 +3,19 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import HeaderBar from '../HeaderBar/HeaderBar';
 import MainContentWrapper from '../MainContentWrapper/MainContentWrapper';
 import { BehandlingerProvider } from '../../context/BehandlingerContext';
+import { InnrapporteringProvider } from '../../context/InnrapporteringContext';
+import { withContextProviders } from '../../context/withContextProviders';
 import './App.css';
 import 'reset-css';
-import { InnrapporteringProvider } from '../../context/InnrapporteringContext';
 
-const App = () => {
-    return (
-        <BehandlingerProvider>
-            <InnrapporteringProvider>
-                <Router>
-                    <HeaderBar />
-                    <MainContentWrapper />
-                </Router>
-            </InnrapporteringProvider>
-        </BehandlingerProvider>
-    );
-};
+const App = withContextProviders(() => (
+    <Router>
+        <HeaderBar />
+        <MainContentWrapper />
+    </Router>
+), [
+    BehandlingerProvider,
+    InnrapporteringProvider
+]);
 
 export default App;

--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -3,7 +3,7 @@
     border-radius: 3px;
     display: flex;
     height: 2rem;
-    width: 20rem;
+    width: 24rem;
 }
 
 .Search input[type='text'] {

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from 'react';
+import ErrorModal from '../widgets/modal/ErrorModal';
 import { BehandlingerContext } from '../../context/BehandlingerContext';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
@@ -33,6 +34,12 @@ const Search = () => {
             <button onClick={() => search(ref.current.value)}>
                 <FontAwesomeIcon icon={faSearch} />
             </button>
+            {behandlingerCtx.error && (
+                <ErrorModal
+                    errorMessage={behandlingerCtx.error}
+                    onClose={() => behandlingerCtx.clearError()}
+                />
+            )}
         </div>
     );
 };

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -2,7 +2,6 @@ import React, { useContext, useRef } from 'react';
 import { BehandlingerContext } from '../../context/BehandlingerContext';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
-import { behandlingerFor } from '../../io/http';
 import { Keys } from '../../hooks/useKeyboard';
 import './Search.css';
 
@@ -19,13 +18,7 @@ const Search = () => {
 
     const search = value => {
         if (value.trim().length !== 0) {
-            behandlingerFor(value)
-                .then(response => {
-                    behandlingerCtx.setBehandlinger({ behandlinger: response });
-                })
-                .catch(err => {
-                    console.log(err); // eslint-disable-line no-console
-                });
+            behandlingerCtx.fetchBehandlinger(value);
         }
     };
 

--- a/src/components/widgets/Uenigboks.jsx
+++ b/src/components/widgets/Uenigboks.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Checkbox, Input } from 'nav-frontend-skjema';
 import { InnrapporteringContext } from '../../context/InnrapporteringContext';
 import './Uenigboks.css';
+import { useFocusRef } from '../../hooks/useFocusRef';
 
 // Override proptypes til Input for å kunne gi en ref som parameter til inputRef
 Input.propTypes = {
@@ -12,7 +13,6 @@ Input.propTypes = {
 
 const Uenigboks = ({ label }) => {
     const id = label + window.location.pathname;
-    const ref = useRef();
     const innrapportering = useContext(InnrapporteringContext);
 
     const uenighet = useMemo(
@@ -21,15 +21,8 @@ const Uenigboks = ({ label }) => {
     );
 
     const [checked, setChecked] = useState(uenighet !== undefined);
-    const [inputValue, setInputValue] = useState(
-        (uenighet && uenighet.value) || ''
-    );
-
-    useEffect(() => {
-        if (checked && inputValue === '') {
-            ref.current && ref.current.focus();
-        }
-    }, [checked]);
+    const [inputValue, setInputValue] = useState(uenighet && uenighet.value || '');
+    const ref = useFocusRef(checked && inputValue === '');
 
     useEffect(() => {
         innrapportering.updateUenighet(id, inputValue);
@@ -42,10 +35,6 @@ const Uenigboks = ({ label }) => {
         } else {
             innrapportering.removeUenighet(id);
         }
-    };
-
-    const onInputChange = e => {
-        setInputValue(e.target.value);
     };
 
     return (
@@ -61,7 +50,7 @@ const Uenigboks = ({ label }) => {
                 placeholder="Skriv inn årsak til uenighet"
                 inputRef={ref}
                 disabled={!checked}
-                onChange={onInputChange}
+                onChange={e => setInputValue(e.target.value)}
                 value={inputValue}
             />
         </div>

--- a/src/components/widgets/modal/ErrorModal.jsx
+++ b/src/components/widgets/modal/ErrorModal.jsx
@@ -7,7 +7,7 @@ import { Knapp } from 'nav-frontend-knapper';
 
 Modal.setAppElement('#root');
 
-const ErrorModal = ({ errorMessage }) => (
+const ErrorModal = ({ errorMessage, onClose }) => (
     <Modal
         className="ErrorModal"
         isOpen={true}
@@ -17,12 +17,25 @@ const ErrorModal = ({ errorMessage }) => (
         <Systemtittel>Det har oppstått en feil</Systemtittel>
         <Normaltekst>{errorMessage}</Normaltekst>
         <Normaltekst>Prøv igjen senere.</Normaltekst>
-        <Knapp onClick={() => window.location.reload()}>Last inn på nytt</Knapp>
+        <Knapp onClick={() => {
+            if (onClose) {
+                onClose();
+            } else {
+                window.location.reload();
+            }
+        }}>
+            {onClose ? 'Ok' : 'Last inn på nytt'}
+        </Knapp>
     </Modal>
 );
 
 ErrorModal.propTypes = {
-    errorMessage: PropTypes.string.isRequired
+    errorMessage: PropTypes.string.isRequired,
+    onClose: PropTypes.func
+};
+
+ErrorModal.defaultProps = {
+    onClose: undefined
 };
 
 export default ErrorModal;

--- a/src/context/BehandlingerContext.js
+++ b/src/context/BehandlingerContext.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
+import { behandlingerFor } from '../io/http';
 
 export const BehandlingerContext = createContext();
 
@@ -18,11 +19,21 @@ export const withBehandlingContext = Component => {
 export const BehandlingerProvider = ({ children }) => {
     const [behandlinger, setBehandlinger] = useState([]);
 
+    const fetchBehandlinger = value => {
+        behandlingerFor(value)
+            .then(response => {
+                setBehandlinger({ behandlinger: response });
+            })
+            .catch(() => {
+            });
+    };
+
     return (
         <BehandlingerContext.Provider
             value={{
                 state: behandlinger,
-                setBehandlinger: setBehandlinger
+                setBehandlinger: setBehandlinger,
+                fetchBehandlinger
             }}
         >
             {children}

--- a/src/context/BehandlingerContext.js
+++ b/src/context/BehandlingerContext.js
@@ -17,6 +17,7 @@ export const withBehandlingContext = Component => {
 };
 
 export const BehandlingerProvider = ({ children }) => {
+    const [error, setError] = useState(undefined);
     const [behandlinger, setBehandlinger] = useState([]);
 
     const fetchBehandlinger = value => {
@@ -25,6 +26,7 @@ export const BehandlingerProvider = ({ children }) => {
                 setBehandlinger({ behandlinger: response });
             })
             .catch(() => {
+                setError('Kunne ikke utføre søket');
             });
     };
 
@@ -33,7 +35,9 @@ export const BehandlingerProvider = ({ children }) => {
             value={{
                 state: behandlinger,
                 setBehandlinger: setBehandlinger,
-                fetchBehandlinger
+                fetchBehandlinger,
+                error,
+                clearError: () => setError(undefined)
             }}
         >
             {children}

--- a/src/context/InnrapporteringContext.js
+++ b/src/context/InnrapporteringContext.js
@@ -21,11 +21,13 @@ export const InnrapporteringProvider = ({ children }) => {
     };
 
     const updateUenighet = (id, value) => {
-        setUenigheter(uenigheter =>
-            uenigheter.map(uenighet =>
-                uenighet.id === id ? { ...uenighet, value } : uenighet
-            )
-        );
+        setUenigheter(uenigheter => (
+            uenigheter.map(uenighet => (
+                uenighet.id === id
+                    ? { ...uenighet, value }
+                    : uenighet
+            ))
+        ));
     };
 
     return (

--- a/src/context/withContextProviders.jsx
+++ b/src/context/withContextProviders.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const withContextProviders = (Component, contextProviders = []) => {
+    return props => {
+        return contextProviders.reduce(
+            (acc, provider) => React.createElement(provider, null, acc),
+            <Component {...props} />
+        );
+    };
+};

--- a/src/hooks/useFocusRef.js
+++ b/src/hooks/useFocusRef.js
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+export const useFocusRef = predicate => {
+    const ref = useRef();
+
+    useEffect(() => {
+        if (predicate) {
+            ref.current && ref.current.focus();
+        }
+    }, [predicate]);
+
+    return ref;
+};

--- a/tests/components/HeaderBar.test.js
+++ b/tests/components/HeaderBar.test.js
@@ -14,6 +14,9 @@ beforeAll(() => {
     console.log = jest.fn();
 });
 
+jest.mock('../../src/components/widgets/modal/ErrorModal', () => () => <div />);
+jest.mock('../../src/components/Search/Search', () => () => <div />);
+
 afterAll(() => {
     console.log = clgOrig;
 });


### PR DESCRIPTION
- Vis feilmelding når søk feiler
- Flytt logikk rundt fetching av behandlinger fra UI-komponenter over til BehandlingerProvider
- Kombiner kontekst-providere i en HoC for å slippe kode som er dypt nøstet som her:
```javascript
<Provider1>
    <Provider2>
        <Provider3>
            // osv osv...
        </Provider3>
    </Provider2>
</Provider1>
```
HoCen kan brukes slik:
```javascript
const EnKomponent = withContextProviders(() => (
    // Her rendrer man det man vil skal ha tilgang til kontekstene
), [
    Provider1,
    Provider2,
    Provider3
]);
```
