### PR TITLE
Persist feedback

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -15,7 +15,7 @@ const App = withContextProviders(
             <MainContentWrapper />
         </Router>
     ),
-    [BehandlingerProvider, InnrapporteringProvider]
+    [InnrapporteringProvider, BehandlingerProvider]
 );
 
 export default App;

--- a/src/components/widgets/Uenigboks.jsx
+++ b/src/components/widgets/Uenigboks.jsx
@@ -12,7 +12,7 @@ Input.propTypes = {
 };
 
 const Uenigboks = ({ label }) => {
-    const id = label + window.location.pathname;
+    const id = label + decodeURIComponent(window.location.pathname);
     const innrapportering = useContext(InnrapporteringContext);
 
     const uenighet = useMemo(

--- a/src/context/BehandlingerContext.js
+++ b/src/context/BehandlingerContext.js
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { behandlingerFor } from '../io/http';
+import { useSessionStorage } from '../hooks/useSessionStorage';
 
 export const BehandlingerContext = createContext();
 
@@ -18,7 +19,10 @@ export const withBehandlingContext = Component => {
 
 export const BehandlingerProvider = ({ children }) => {
     const [error, setError] = useState(undefined);
-    const [behandlinger, setBehandlinger] = useState([]);
+    const [behandlinger, setBehandlinger] = useSessionStorage(
+        'behandlinger',
+        []
+    );
 
     const fetchBehandlinger = value => {
         behandlingerFor(value)

--- a/src/context/InnrapporteringContext.js
+++ b/src/context/InnrapporteringContext.js
@@ -1,12 +1,13 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useSessionStorage } from '../hooks/useSessionStorage';
 
 export const InnrapporteringContext = createContext({
     uenigheter: []
 });
 
 export const InnrapporteringProvider = ({ children }) => {
-    const [uenigheter, setUenigheter] = useState([]);
+    const [uenigheter, setUenigheter] = useSessionStorage('uenigheter', []);
 
     const removeUenighet = id => {
         setUenigheter(uenigheter =>

--- a/src/context/InnrapporteringContext.js
+++ b/src/context/InnrapporteringContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext } from 'react';
 import PropTypes from 'prop-types';
 import { useSessionStorage } from '../hooks/useSessionStorage';
 

--- a/src/context/InnrapporteringContext.js
+++ b/src/context/InnrapporteringContext.js
@@ -1,48 +1,55 @@
 import React, { createContext } from 'react';
 import PropTypes from 'prop-types';
 import { useSessionStorage } from '../hooks/useSessionStorage';
+import { withBehandlingContext } from './BehandlingerContext';
 
 export const InnrapporteringContext = createContext({
     uenigheter: []
 });
 
-export const InnrapporteringProvider = ({ children }) => {
-    const [uenigheter, setUenigheter] = useSessionStorage('uenigheter', []);
-
-    const removeUenighet = id => {
-        setUenigheter(uenigheter =>
-            uenigheter.filter(uenighet => uenighet.id !== id)
+export const InnrapporteringProvider = withBehandlingContext(
+    ({ behandling, children }) => {
+        const behandlingsId = behandling && behandling.behandlingsId;
+        const [uenigheter, setUenigheter] = useSessionStorage(
+            `uenigheter-${behandlingsId}`,
+            []
         );
-    };
 
-    const addUenighet = (id, label) => {
-        if (!uenigheter.find(uenighet => uenighet.id === id)) {
-            setUenigheter(uenigheter => [...uenigheter, { id, label }]);
-        }
-    };
+        const removeUenighet = id => {
+            setUenigheter(uenigheter =>
+                uenigheter.filter(uenighet => uenighet.id !== id)
+            );
+        };
 
-    const updateUenighet = (id, value) => {
-        setUenigheter(uenigheter =>
-            uenigheter.map(uenighet =>
-                uenighet.id === id ? { ...uenighet, value } : uenighet
-            )
+        const addUenighet = (id, label) => {
+            if (!uenigheter.find(uenighet => uenighet.id === id)) {
+                setUenigheter(uenigheter => [...uenigheter, { id, label }]);
+            }
+        };
+
+        const updateUenighet = (id, value) => {
+            setUenigheter(uenigheter =>
+                uenigheter.map(uenighet =>
+                    uenighet.id === id ? { ...uenighet, value } : uenighet
+                )
+            );
+        };
+
+        return (
+            <InnrapporteringContext.Provider
+                value={{
+                    uenigheter,
+                    setUenigheter,
+                    removeUenighet,
+                    addUenighet,
+                    updateUenighet
+                }}
+            >
+                {children}
+            </InnrapporteringContext.Provider>
         );
-    };
-
-    return (
-        <InnrapporteringContext.Provider
-            value={{
-                uenigheter,
-                setUenigheter,
-                removeUenighet,
-                addUenighet,
-                updateUenighet
-            }}
-        >
-            {children}
-        </InnrapporteringContext.Provider>
-    );
-};
+    }
+);
 
 InnrapporteringProvider.propTypes = {
     children: PropTypes.node.isRequired

--- a/src/hooks/useSessionStorage.js
+++ b/src/hooks/useSessionStorage.js
@@ -20,7 +20,7 @@ export const useSessionStorage = (key, initialValue) => {
             const parsedState = JSON.parse(decodeURIComponent(sessionState));
             setState(parsedState);
         }
-    }, []);
+    }, [key]);
 
     return [state, setState];
 };

--- a/src/hooks/useSessionStorage.js
+++ b/src/hooks/useSessionStorage.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+/* Utvider useState ved å lagre/hente state i/fra sessionStorage.
+ * @param {string} key          nøkkel for lagring i sessionStorage
+ * @param {any} initialValue    initiell verdi for state
+ * returns {array}              et array bestående av verdien av state og en setState-funksjon
+ */
+export const useSessionStorage = (key, initialValue) => {
+    const [state, setState] = useState(initialValue);
+
+    useEffect(() => {
+        if (state !== initialValue) {
+            sessionStorage.setItem(key, JSON.stringify(state));
+        }
+    }, [state]);
+
+    useEffect(() => {
+        const sessionState = sessionStorage.getItem(key);
+        if (sessionState) {
+            const parsedState = JSON.parse(decodeURIComponent(sessionState));
+            setState(parsedState);
+        }
+    }, []);
+
+    return [state, setState];
+};

--- a/tests/hooks/useSessionStorage.test.js
+++ b/tests/hooks/useSessionStorage.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, fireEvent, getByTestId } from 'react-testing-library';
+import { useSessionStorage } from '../../src/hooks/useSessionStorage';
+
+const Container = () => {
+    const [state, setState] = useSessionStorage('test', 0);
+
+    return (
+        <>
+            <div data-testid="stateValue">{state}</div>
+            <button
+                data-testid="increment"
+                onClick={() => setState(state + 1)}
+            />
+            <button
+                data-testid="decrement"
+                onClick={() => setState(state - 1)}
+            />
+        </>
+    );
+};
+
+const mockStorage = {};
+
+beforeAll(() => {
+    global.sessionStorage = {};
+    global.sessionStorage.setItem = (key, value) => (mockStorage[key] = value);
+    global.sessionStorage.getItem = key => mockStorage[key];
+});
+
+afterAll(() => {
+    global.sessionStorage = null;
+});
+
+describe('useSessionStorage', () => {
+    it('updates state', () => {
+        const container = render(<Container />).container;
+        const stateValue = getByTestId(container, 'stateValue');
+        const incrementButton = getByTestId(container, 'increment');
+        const decrementButton = getByTestId(container, 'decrement');
+
+        expect(stateValue.textContent).toBe('0');
+        fireEvent.click(incrementButton);
+        expect(stateValue.textContent).toBe('1');
+        fireEvent.click(decrementButton);
+        fireEvent.click(decrementButton);
+        expect(stateValue.textContent).toBe('-1');
+    });
+
+    it('persists state', () => {
+        const container = render(<Container />).container;
+        const stateValue = getByTestId(container, 'stateValue');
+        expect(stateValue.textContent).toBe('-1');
+    });
+});


### PR DESCRIPTION
- Lager en hook `useSessionStorage` for å lagre state om bruker laster inn siden på nytt. Dette for å spare bruker for tap av potensielt mye arbeid mtp. innrapportering av feil/uenigheter.
- Bruker `useSessionStorage` også for `BehandlingerProvider` slik at behandlingsdataene ikke forsvinner om bruker laster inn siden på nytt.