### PR TITLE
Use search icon instead of unicode character

### DIFF
--- a/src/components/Search/Search.css
+++ b/src/components/Search/Search.css
@@ -42,8 +42,3 @@
 .Search button:active {
     background: black;
 }
-
-.Search button svg.svg-inline--fa {
-    width: 1rem;
-    height: 1rem;
-}

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -4,6 +4,31 @@ import { BehandlingerContext } from '../../context/BehandlingerContext';
 import { Keys } from '../../hooks/useKeyboard';
 import './Search.css';
 
+const SearchIcon = () => (
+    <svg
+        version="1.1"
+        id="Filled_Version"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlnsXlink="http://www.w3.org/1999/xlink"
+        x="0px"
+        y="0px"
+        width="16px"
+        height="16px"
+        viewBox="0 0 24 24"
+        enableBackground="new 0 0 24 24"
+        xmlSpace="preserve"
+    >
+        <g>
+            <path
+                fill="#fff"
+                d="M9,18c2.131,0,4.09-0.75,5.633-1.992l7.658,7.697c0.389,0.393,1.021,0.395,1.414,0.004s0.393-1.023,0.004-1.414
+                l-7.668-7.707C17.264,13.053,18,11.111,18,9c0-4.963-4.037-9-9-9S0,4.037,0,9S4.037,18,9,18z M9,2c3.859,0,7,3.139,7,7
+                c0,3.859-3.141,7-7,7c-3.861,0-7-3.141-7-7C2,5.139,5.139,2,9,2z"
+            />
+        </g>
+    </svg>
+);
+
 const Search = () => {
     const ref = useRef(undefined);
     const behandlingerCtx = useContext(BehandlingerContext);
@@ -29,7 +54,9 @@ const Search = () => {
                 placeholder="FNR eller aktør"
                 onKeyPress={keyTyped}
             />
-            <button onClick={() => search(ref.current.value)}>&#x1F50D;</button>
+            <button onClick={() => search(ref.current.value)}>
+                <SearchIcon />
+            </button>
             {behandlingerCtx.error && (
                 <ErrorModal
                     errorMessage={behandlingerCtx.error}


### PR DESCRIPTION
Unicode-karakteren `&#x1F50D;` ser forskjellig ut i forskjellige miljøer. Testet speil på utviklerimage hvor man så en ⬜️ i stedet for et 🔍. Bruker en svg for å slippe dette problemet.