### PR TITLE
Add docker-compose file for running LocalStack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yarn-error.log*
 *.swo
 .cache/
 .env
+.localstack/

--- a/README.md
+++ b/README.md
@@ -34,9 +34,15 @@ SESSION_SECRET=whatever
 Hvis du vil benytte funksjonaliteten for lagring og henting av feedback for en sak må du tilby et S3-kompatibelt endepunkt, her kan feks [LocalStack](https://hub.docker.com/r/localstack/localstack) benyttes. Følgende må da inn i .env-fila i tillegg til det som er nevnt ovenfor:
 
 ```
-S3_URL=http://<my-s3>
+S3_URL=http://localhost:4572
 S3_ACCESS_KEY=<key>
 S3_SECRET_KEY=<secret>
+```
+
+Kjør LocalStack:
+
+```
+npm run mock-s3
 ```
 
 Bygg/pakk frontend:

--- a/__mocks__/s3-docker-compose.yaml
+++ b/__mocks__/s3-docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3.2'
+services:
+  localstack:
+    image: localstack/localstack:latest
+    container_name: localstack_demo
+    ports:
+      - '4563-4584:4563-4584'
+      - '8055:8080'
+    environment:
+      - SERVICES=s3
+      - DEBUG=1
+      - DATA_DIR=/tmp/localstack/data
+    volumes:
+      - './.localstack:/tmp/localstack'
+      - '/var/run/docker.sock:/var/run/docker.sock'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "start": "NODE_ENV=development parcel src/index.html --open",
         "start-express": "DEBUG=express:* node src/server/server.js --experimental-modules",
         "dev-express": "DEBUG=express:* NODE_ENV=development nodemon src/server/server.js --experimental-modules",
+        "mock-s3": "docker-compose --file __mocks__/s3-docker-compose.yaml up",
         "build": "npm run test && npm run clean:dist && parcel build src/index.html --public-url ./ --no-source-maps",
         "clean:dist": "rimraf dist",
         "prettier": "prettier --write \"src/**/*.{jsx,js,css}\"",


### PR DESCRIPTION
Legger til docker-compose-fila til @jksolbakken å enkelt kunne kjøre LocalStack om man trenger tilgang til s3 lokalt. La også til et script i package.json for å enkelt kjøre denne: `npm run mock-s3`