### PR TITLE
Omgå bug i Modal fra designsystemet

### DIFF
--- a/src/components/widgets/modal/ErrorModal.jsx
+++ b/src/components/widgets/modal/ErrorModal.jsx
@@ -13,6 +13,7 @@ const ErrorModal = ({ errorMessage, onClose }) => (
         isOpen={true}
         contentLabel="Feilmelding"
         closeButton={false}
+        onRequestClose={onClose || (() => {})}
     >
         <Systemtittel>Det har oppstått en feil</Systemtittel>
         <Normaltekst>{errorMessage}</Normaltekst>


### PR DESCRIPTION
Modal forventer at onRequestClose skal være en definert funksjon. Det lar seg
ikke gjøre å lukke modalen ved å klikke utenfor modalen uten denne.