### PR TITLE
Refactor feedback

### DIFF
--- a/src/server/feedback/feedbackroutes.js
+++ b/src/server/feedback/feedbackroutes.js
@@ -1,10 +1,16 @@
 'use strict';
 
+const moment = require('moment');
+const utils = require('./utils');
 const storage = require('./storage');
 const { ipAddressFromRequest } = require('../requestData.js');
-const { log } = require('../logging');
-const moment = require('moment');
 const { csvMapper } = require('./feedback-csv-mapper');
+const { log } = require('../logging');
+
+const ContentType = {
+    JSON: 'application/json',
+    CSV: 'text/csv'
+};
 
 const setup = (app, config) => {
     return new Promise((resolve, reject) => {
@@ -40,11 +46,38 @@ const routes = app => {
             });
     });
 
-    app.get('/feedback-json', async (req, res) => {
+    app.get('/feedback', async (req, res) => {
+        const date = await utils.parseDate(req.query.fraogmed).catch(err => {
+            res.send(err);
+            return;
+        });
+
         storage
             .loadAll()
-            .then(objects => {
-                res.send(objects);
+            .then(feedback => {
+                const response = date
+                    ? utils.excludeOlderFeedback(date, feedback)
+                    : feedback;
+                log(
+                    `Will return ${response.length} feedbacks to client, out of ${feedback.length} fetched from storage`
+                );
+
+                if (req.accepts(ContentType.CSV)) {
+                    const csvFeedback = csvMapper(response);
+                    const timestamp = moment().format('YYYY-MM-DDTHH.mm.ss');
+                    log(
+                        `Mapped CSV file is ${csvFeedback.length} characters long.`
+                    );
+                    res.setHeader(
+                        'Content-Disposition',
+                        `attachment; filename=tilbakemeldinger_${timestamp}.csv`
+                    );
+                    res.setHeader('Content-Type', ContentType.CSV);
+                    res.send(csvFeedback);
+                } else {
+                    res.setHeader('Content-Type', ContentType.JSON);
+                    res.send(response);
+                }
             })
             .catch(err => {
                 console.warn(err);
@@ -52,50 +85,9 @@ const routes = app => {
             });
     });
 
-    app.get('/feedback', async (req, res) => {
-        let fom;
-        const fomFromQuery = req.query.fraogmed;
-        if (fomFromQuery !== undefined) {
-            try {
-                fom = convertToMoment(fomFromQuery);
-                log(
-                    `Parsed feedback search params '${fomFromQuery}' to ${fom}.`
-                );
-            } catch (e) {
-                console.warn(e.message);
-                res.send(
-                    `Det lot seg ikke gjøre å tolke '${fomFromQuery}' som en dato`
-                );
-                return;
-            }
-        }
-
-        const feedback = await storage.loadAll().catch(err => {
-            console.warn(err);
-            res.sendStatus(err.statusCode || 500);
-            return;
-        });
-
-        const response =
-            fom !== undefined ? excludeOlderFeedback(fom, feedback) : feedback;
-        log(
-            `Will return ${response.length} feedbacks to client, out of ${feedback.length} fetched from storage`
-        );
-
-        const timestamp = moment().format('YYYY-MM-DDTHH.mm.ss');
-        res.setHeader(
-            'Content-Disposition',
-            `attachment; filename=tilbakemeldinger_${timestamp}.csv`
-        );
-        res.setHeader('Content-Type', 'text/csv');
-        const csvResponse = csvMapper(response);
-        log(`Mapped CSV file is ${csvResponse.length} characters long.`);
-        res.send(csvResponse);
-    });
-
     app.put('/feedback', (req, res) => {
         log(`Storing feedback from IP address ${ipAddressFromRequest(req)}`);
-        if (isInvalid(req)) {
+        if (utils.isInvalid(req)) {
             log(`Rejecting feedback due to validation error`);
             res.sendStatus(400);
         } else {
@@ -112,33 +104,6 @@ const routes = app => {
     });
 };
 
-const convertToMoment = dateString => {
-    const norwegianMoment = moment(dateString, 'DD.MM.YYYY');
-    if (norwegianMoment.isValid()) {
-        return norwegianMoment;
-    }
-    const isoMoment = moment(dateString, 'YYYY-MM-DD');
-    if (isoMoment.isValid()) {
-        return isoMoment;
-    }
-    throw new Error('not a parseable date: ' + dateString);
-};
-
-const excludeOlderFeedback = (fom, feedback) =>
-    feedback.filter(f => moment(f.value.submittedDate || -1).isAfter(fom));
-
-const isInvalid = req => {
-    return (
-        !req.body.id ||
-        !req.body.txt ||
-        req.body.id.length === 0 ||
-        req.body.id.length > 50 ||
-        req.body.txt.length === 0 ||
-        req.body.txt.length > 20000
-    );
-};
-
 module.exports = {
-    setup: setup,
-    _convertToMoment: convertToMoment
+    setup: setup
 };

--- a/src/server/feedback/feedbackroutes.js
+++ b/src/server/feedback/feedbackroutes.js
@@ -47,7 +47,7 @@ const routes = app => {
     });
 
     app.get('/feedback', async (req, res) => {
-        const date = await utils.parseDate(req.query.fraogmed).catch(err => {
+        const date = utils.parseDate(req.query.fraogmed).catch(err => {
             res.send(err);
             return;
         });

--- a/src/server/feedback/utils.js
+++ b/src/server/feedback/utils.js
@@ -10,7 +10,6 @@ const parseDate = date => {
         if (isoMoment.isValid()) {
             resolve(isoMoment);
         }
-        console.warn('not a parseable date: ' + date);
         reject(`Det lot seg ikke gjøre å tolke '${date}' som en dato`);
     });
 };

--- a/src/server/feedback/utils.js
+++ b/src/server/feedback/utils.js
@@ -1,0 +1,51 @@
+const moment = require('moment');
+const { log } = require('../logging');
+
+const parseDate = date => {
+    return new Promise((resolve, reject) => {
+        let fom;
+        if (date !== undefined) {
+            try {
+                fom = convertToMoment(date);
+                log(`Parsed feedback search params '${date}' to ${fom}.`);
+            } catch (e) {
+                console.warn(e.message);
+                reject(`Det lot seg ikke gjøre å tolke '${date}' som en dato`);
+            }
+        }
+        resolve(fom);
+    });
+};
+
+const convertToMoment = dateString => {
+    const norwegianMoment = moment(dateString, 'DD.MM.YYYY');
+    if (norwegianMoment.isValid()) {
+        return norwegianMoment;
+    }
+    const isoMoment = moment(dateString, 'YYYY-MM-DD');
+    if (isoMoment.isValid()) {
+        return isoMoment;
+    }
+    throw new Error('not a parseable date: ' + dateString);
+};
+
+const excludeOlderFeedback = (fom, feedback) =>
+    feedback.filter(f => moment(f.value.submittedDate || -1).isAfter(fom));
+
+const isInvalid = req => {
+    return (
+        !req.body.id ||
+        !req.body.txt ||
+        req.body.id.length === 0 ||
+        req.body.id.length > 50 ||
+        req.body.txt.length === 0 ||
+        req.body.txt.length > 20000
+    );
+};
+
+module.exports = {
+    parseDate,
+    convertToMoment,
+    excludeOlderFeedback,
+    isInvalid
+};

--- a/src/server/feedback/utils.js
+++ b/src/server/feedback/utils.js
@@ -1,32 +1,18 @@
 const moment = require('moment');
-const { log } = require('../logging');
 
 const parseDate = date => {
     return new Promise((resolve, reject) => {
-        let fom;
-        if (date !== undefined) {
-            try {
-                fom = convertToMoment(date);
-                log(`Parsed feedback search params '${date}' to ${fom}.`);
-            } catch (e) {
-                console.warn(e.message);
-                reject(`Det lot seg ikke gjøre å tolke '${date}' som en dato`);
-            }
+        const norwegianMoment = moment(date, 'DD.MM.YYYY');
+        if (norwegianMoment.isValid()) {
+            resolve(norwegianMoment);
         }
-        resolve(fom);
+        const isoMoment = moment(date, 'YYYY-MM-DD');
+        if (isoMoment.isValid()) {
+            resolve(isoMoment);
+        }
+        console.warn('not a parseable date: ' + date);
+        reject(`Det lot seg ikke gjøre å tolke '${date}' som en dato`);
     });
-};
-
-const convertToMoment = dateString => {
-    const norwegianMoment = moment(dateString, 'DD.MM.YYYY');
-    if (norwegianMoment.isValid()) {
-        return norwegianMoment;
-    }
-    const isoMoment = moment(dateString, 'YYYY-MM-DD');
-    if (isoMoment.isValid()) {
-        return isoMoment;
-    }
-    throw new Error('not a parseable date: ' + dateString);
 };
 
 const excludeOlderFeedback = (fom, feedback) =>
@@ -45,7 +31,6 @@ const isInvalid = req => {
 
 module.exports = {
     parseDate,
-    convertToMoment,
     excludeOlderFeedback,
     isInvalid
 };

--- a/src/server/feedback/utils.test.js
+++ b/src/server/feedback/utils.test.js
@@ -1,13 +1,13 @@
-const { _convertToMoment } = require('./feedbackroutes');
+const { convertToMoment } = require('./utils');
 
 describe('date validation', () => {
     test('accepts norwegian and ISO-8601 date formats', () => {
         ['01.01.2019', '01.01.19', '2019-01-01'].forEach(input => {
-            expect(_convertToMoment(input).isSame('2019-01-01')).toBeTruthy();
+            expect(convertToMoment(input).isSame('2019-01-01')).toBeTruthy();
         });
     });
 
     test('throws if input does not parse', () => {
-        expect(() => _convertToMoment('bomb')).toThrow(Error);
+        expect(() => convertToMoment('bomb')).toThrow(Error);
     });
 });

--- a/src/server/feedback/utils.test.js
+++ b/src/server/feedback/utils.test.js
@@ -4,13 +4,16 @@ describe('date validation', () => {
     test('accepts norwegian and ISO-8601 date formats', () => {
         ['01.01.2019', '01.01.19', '2019-01-01'].forEach(async input => {
             await parseDate(input).then(date => {
-                console.log('meh');
                 expect(date.isSame('2019-01-01')).toBeTruthy();
             });
         });
     });
 
-    test('throws if input does not parse', () => {
-        expect(() => parseDate('bomb')).toThrow(Error);
+    test('throws if input does not parse', async () => {
+        await parseDate('bomb').catch(err => {
+            expect(err).toEqual(
+                "Det lot seg ikke gjøre å tolke 'bomb' som en dato"
+            );
+        });
     });
 });

--- a/src/server/feedback/utils.test.js
+++ b/src/server/feedback/utils.test.js
@@ -1,13 +1,16 @@
-const { convertToMoment } = require('./utils');
+const { parseDate } = require('./utils');
 
 describe('date validation', () => {
     test('accepts norwegian and ISO-8601 date formats', () => {
-        ['01.01.2019', '01.01.19', '2019-01-01'].forEach(input => {
-            expect(convertToMoment(input).isSame('2019-01-01')).toBeTruthy();
+        ['01.01.2019', '01.01.19', '2019-01-01'].forEach(async input => {
+            await parseDate(input).then(date => {
+                console.log('meh');
+                expect(date.isSame('2019-01-01')).toBeTruthy();
+            });
         });
     });
 
     test('throws if input does not parse', () => {
-        expect(() => convertToMoment('bomb')).toThrow(Error);
+        expect(() => parseDate('bomb')).toThrow(Error);
     });
 });


### PR DESCRIPTION
- Fjerner `/feedback-json` til fordel for én route som svarer med enten json eller csv basert på `Accept`-headeren.
- Legger funksjoner som ikke har noe med routing å gjøre i egen utility-fil, `src/server/feedback/utils.js`