### PR TITLE
Only use Redis session store in prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
                      docker push $DOCKER_IMG_NAME:$COMMIT_SHORT
                  else
                      echo "No need to create Docker images for pull requests"
+                     touch shared_env
                  fi
          - persist_to_workspace:
               root: ~/speil

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -3,7 +3,6 @@
 const config = require('./config');
 
 const express = require('express');
-const expressSession = require('express-session');
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const compression = require('compression');
@@ -11,9 +10,7 @@ const { generators } = require('openid-client');
 
 const azure = require('./auth/azure');
 const authsupport = require('./auth/authsupport');
-
-const redis = require('redis');
-const redisStore = require('connect-redis')(expressSession);
+const { sessionStore } = require('./sessionstore');
 
 const metrics = require('./metrics');
 const headers = require('./headers');
@@ -32,19 +29,8 @@ const port = config.server.port;
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(cookieParser());
-app.use(
-    expressSession({
-        secret: config.server.sessionSecret,
-        ttl: 43200, // 12 hours
-        store: new redisStore({
-            client: redis.createClient({
-                host: config.redis.host,
-                port: config.redis.port,
-                password: config.redis.password
-            })
-        })
-    })
-);
+
+app.use(sessionStore(config));
 app.use(compression());
 
 headers.setup(app);

--- a/src/server/sessionstore.js
+++ b/src/server/sessionstore.js
@@ -1,0 +1,35 @@
+const expressSession = require('express-session');
+const redisStore = require('connect-redis')(expressSession);
+const redis = require('redis');
+
+const sessionStore = config => {
+    return process.env.NODE_ENV === 'development'
+        ? createMemoryStoreSession(config)
+        : createRedisSession(config);
+};
+
+const createMemoryStoreSession = config => {
+    console.log('Setting up MemoryStore session store');
+
+    return expressSession({ secret: config.server.sessionSecret });
+};
+
+const createRedisSession = config => {
+    console.log('Setting up Redis session store');
+
+    return expressSession({
+        secret: config.server.sessionSecret,
+        ttl: 43200, // 12 hours
+        store: new redisStore({
+            client: redis.createClient({
+                host: config.redis.host,
+                port: config.redis.port,
+                password: config.redis.password
+            })
+        })
+    });
+};
+
+module.exports = {
+    sessionStore
+};


### PR DESCRIPTION
This removes the need to have Redis running in order to start the
application on developer machines.