### PR TITLE
Fix styling for details-button

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -20,10 +20,12 @@ svg[kind='ok-sirkel-fyll'] g path:first-child {
 .vis-modal-button {
     cursor: pointer;
     -webkit-appearance: none;
-    background-color: #fff;
+    background: none;
     border: none;
-    font: inherit;
-    margin-left: 0.3rem;
     padding: 0;
-    color: inherit;
+    color: #0067c5;
+    font-size: 14px;
+    font-weight: 400;
+    font-family: inherit;
+    text-decoration: underline;
 }

--- a/src/components/pages/Beregning/Beregning.jsx
+++ b/src/components/pages/Beregning/Beregning.jsx
@@ -17,7 +17,7 @@ const Beregning = withBehandlingContext(({ behandling }) => {
 
     const detaljerKnapp = (
         <button className="vis-modal-button" onClick={() => setVisDetaljerboks(true)} tabIndex={0}>
-            (Vis detaljer)
+            Vis detaljer
         </button>
     );
 

--- a/src/components/pages/Inngangsvilkår/Inngangsvilkår.jsx
+++ b/src/components/pages/Inngangsvilkår/Inngangsvilkår.jsx
@@ -14,7 +14,7 @@ const Inngangsvilkår = withBehandlingContext(({ behandling }) => {
 
     const detaljerKnapp = (
         <button className="vis-modal-button" onClick={() => setVisDetaljerboks(true)} tabIndex={0}>
-            (Vis detaljer)
+            Vis detaljer
         </button>
     );
     return (

--- a/src/components/widgets/rows/IconRow.less
+++ b/src/components/widgets/rows/IconRow.less
@@ -4,7 +4,8 @@
   .IconRow__left {
     display: flex;
     flex: 2;
-    align-items: center;
+    align-items: flex-start;
+    padding-top: 0.75rem;
 
     > svg {
       margin-right: 1rem;
@@ -13,7 +14,7 @@
     > span.divider {
       flex: 1;
       border-top: 1px dotted #000;
-      margin: 0 1rem;
+      margin: 0.75rem;
     }
 
     .typo-normal:last-child {
@@ -22,6 +23,16 @@
 
     .typo-normal.bold {
       font-weight: 600;
+    }
+
+    > p:nth-child(2) {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+
+      > .vis-modal-button {
+        margin-bottom: 1rem;
+      }
     }
   }
 


### PR DESCRIPTION
Endret styling for "Vis detaljer"-knapp basert på [dette](https://trello.com/c/YXpFbLGQ/159-vis-detaljer-i-speil-uthevet-eller-blå-sånn-at-de-ser-at-de-er-trykkbare) kortet.