### PR TITLE
Avoid NNINs in URLs

### DIFF
--- a/src/io/http.js
+++ b/src/io/http.js
@@ -17,8 +17,8 @@ const getData = async response => {
     }
 };
 
-const get = async url => {
-    const response = await fetch(url);
+const get = async (url, options) => {
+    const response = await fetch(url, options);
 
     if (response.status >= 400) {
         throw ResponseError(response.statusText, response.status);
@@ -31,7 +31,9 @@ const get = async url => {
 };
 
 export const behandlingerFor = async aktorId => {
-    return get(`${baseUrl}/behandlinger/${aktorId}`);
+    return get(`${baseUrl}/behandlinger/`, {
+        headers: { 'nav-person-id': aktorId }
+    });
 };
 
 export const putFeedback = async feedback => {

--- a/src/server/behandlinger/behandlingerroutes.js
+++ b/src/server/behandlinger/behandlingerroutes.js
@@ -10,12 +10,11 @@ const { isValidSsn } = require('../aktørid/ssnvalidation');
 const setup = ({ app, stsclient, config }) => {
     aktøridlookup.init(stsclient, config);
 
-    app.get('/behandlinger/:personId', async (req, res) => {
+    app.get('/behandlinger/', async (req, res) => {
+        const personId = req.headers['nav-person-id'];
         if (process.env.NODE_ENV === 'development') {
             const filename =
-                req.params.personId.charAt(0) < 5
-                    ? 'behandlinger.json'
-                    : 'behandlinger_mapped.json';
+                personId.charAt(0) < 5 ? 'behandlinger.json' : 'behandlinger_mapped.json';
             fs.readFile(`__mock-data__/${filename}`, (err, data) => {
                 if (err) {
                     console.log(err);
@@ -33,7 +32,6 @@ const setup = ({ app, stsclient, config }) => {
             return;
         }
 
-        const personId = req.params.personId;
         let aktorId;
         if (isValidSsn(personId)) {
             aktorId = await aktøridlookup.hentAktørId(personId).catch(err => {

--- a/src/server/headers.js
+++ b/src/server/headers.js
@@ -26,7 +26,7 @@ const setup = app => {
             res.header('Access-Control-Allow-Origin', 'http://localhost:1234');
             res.header(
                 'Access-Control-Allow-Headers',
-                'Origin, X-Requested-With, Content-Type, Accept'
+                'Origin, X-Requested-With, Content-Type, Accept, nav-person-id'
             );
             res.header('Access-Control-Allow-Methods', 'PUT, GET');
         }


### PR DESCRIPTION
To be in compliance with current security policy we avoid submitting
NNINs as URL fragments. Logging NNIN in access logs is frowned upon.

I wanted to name the header 'NAV-Person-ID', but the fetch API lower
cases header names, so in order to avoid confusion I chose to refer to
it using lower case everywhere.