### PR TITLE
Display NNIN for current applicant

### DIFF
--- a/__mocks__/request-promise-native.js
+++ b/__mocks__/request-promise-native.js
@@ -22,6 +22,8 @@ rpn.get = options => {
                 access_token: createToken({ exp: 12345 })
             });
         }
+    } else if (options.uri.includes('/api/v1/identer')) {
+        return handleAktørregisteretRequest();
     } else {
         if (options.uri.includes('11111')) {
             return Promise.resolve(testPerson);
@@ -31,11 +33,18 @@ rpn.get = options => {
     }
 };
 
+const handleAktørregisteretRequest = () => {
+    return Promise.resolve(aktørregisteretResponse);
+};
+
+let aktørregisteretResponse;
+rpn.prepareAktørregisteretResponse = response => {
+    aktørregisteretResponse = response;
+};
+
 const createToken = claims => {
     const header = { alg: 'HS256', typ: 'JWT' };
-    return `${btoa(JSON.stringify(header))}.${btoa(
-        JSON.stringify(claims)
-    )}.bogussignature`;
+    return `${btoa(JSON.stringify(header))}.${btoa(JSON.stringify(claims))}.bogussignature`;
 };
 
 module.exports = rpn;

--- a/src/components/widgets/Personinfo/Personinfo.jsx
+++ b/src/components/widgets/Personinfo/Personinfo.jsx
@@ -4,7 +4,7 @@ import { Element, Undertekst } from 'nav-frontend-typografi';
 import { withBehandlingContext } from '../../../context/BehandlingerContext';
 import { getPerson } from '../../../io/http';
 
-const Personinfo = withBehandlingContext(({ behandling }) => {
+const Personinfo = withBehandlingContext(({ behandling, fnr }) => {
     const { aktorId } = behandling.originalSøknad;
     const [person, setPerson] = useState();
 
@@ -32,6 +32,7 @@ const Personinfo = withBehandlingContext(({ behandling }) => {
                         className={person.kjønn.toLowerCase()}
                     />
                     <Element>{person.navn}</Element>
+                    <Undertekst>Fødselsnummer: {fnr}</Undertekst>
                     <Undertekst>Aktør-ID: {aktorId}</Undertekst>
                 </div>
             )}

--- a/src/context/BehandlingerContext.js
+++ b/src/context/BehandlingerContext.js
@@ -15,6 +15,7 @@ export const withBehandlingContext = Component => {
                 behandlinger={behandlinger}
                 behandling={behandlingerCtx.valgtBehandling}
                 setValgtBehandling={behandlingerCtx.setValgtBehandling}
+                fnr={behandlingerCtx.fnr}
                 {...props}
             />
         );
@@ -23,6 +24,7 @@ export const withBehandlingContext = Component => {
 export const BehandlingerProvider = ({ children }) => {
     const [error, setError] = useState(undefined);
     const [behandlinger, setBehandlinger] = useSessionStorage('behandlinger', []);
+    const [fnr, setFnr] = useState(undefined);
     const [valgtBehandling, setValgtBehandling] = useState(undefined);
 
     const velgBehandling = behandling => {
@@ -35,7 +37,8 @@ export const BehandlingerProvider = ({ children }) => {
     const fetchBehandlinger = value => {
         return behandlingerFor(value)
             .then(response => {
-                const newData = { behandlinger: response.data };
+                setFnr(response.data.fnr);
+                const newData = { behandlinger: response.data.behandlinger };
                 setBehandlinger(newData.behandlinger);
                 if (newData.behandlinger?.length !== 1) {
                     setValgtBehandling(undefined);
@@ -69,6 +72,7 @@ export const BehandlingerProvider = ({ children }) => {
                 setValgtBehandling: velgBehandling,
                 valgtBehandling,
                 fetchBehandlinger,
+                fnr,
                 error,
                 clearError: () => setError(undefined)
             }}

--- a/src/server/aktørid/aktøridlookup.js
+++ b/src/server/aktørid/aktøridlookup.js
@@ -11,24 +11,16 @@ const init = (stsclient, config) => {
 };
 
 const hentAktørId = async ssn => {
-    const stsToken = await stsClient.hentAccessToken();
-
-    const options = {
-        uri: `${aktørregisterUrl}/api/v1/identer?gjeldende=true`,
-        headers: {
-            Authorization: `Bearer ${stsToken}`,
-            Accept: 'application/json',
-            'Nav-Call-Id': uuid(),
-            'Nav-Consumer-Id': 'speil',
-            'Nav-Personidenter': ssn
-        },
-        json: true
-    };
-
-    return request.get(options).then(response => mapToAktørId(response, ssn));
+    const response = await fetchFromAktørregisteret(ssn);
+    return mapToAktørId(response, ssn);
 };
 
 const hentFnr = async aktørId => {
+    const response = await fetchFromAktørregisteret(aktørId);
+    return mapToFnr(response, aktørId);
+};
+
+const fetchFromAktørregisteret = async ident => {
     const stsToken = await stsClient.hentAccessToken();
 
     const options = {
@@ -38,12 +30,12 @@ const hentFnr = async aktørId => {
             Accept: 'application/json',
             'Nav-Call-Id': uuid(),
             'Nav-Consumer-Id': 'speil',
-            'Nav-Personidenter': aktørId
+            'Nav-Personidenter': ident
         },
         json: true
     };
 
-    return request.get(options).then(response => mapToFnr(response, aktørId));
+    return request.get(options);
 };
 
 const mapToAktørId = (response, ssn) => {
@@ -94,5 +86,6 @@ module.exports = {
     hentAktørId,
     hentFnr,
     _mapToAktørId: mapToAktørId,
+    _mapToFnr: mapToFnr,
     _maskIdentifier: maskIdentifier
 };

--- a/src/server/aktørid/aktøridlookup.test.js
+++ b/src/server/aktørid/aktøridlookup.test.js
@@ -1,11 +1,11 @@
-const aktøridlookup = require('./aktøridlookup');
+const sut = require('./aktøridlookup');
 
 describe('response mapping', () => {
     test('maps OK response correctly', () => {
         const ssn = '140819';
         const aktørId = '1000036876618';
 
-        expect(aktøridlookup._mapResponse(okResponse(ssn, aktørId), ssn)).resolves.toEqual(aktørId);
+        expect(sut._mapToAktørId(okResponse(ssn, aktørId), ssn)).resolves.toEqual(aktørId);
     });
 
     test('rejects on error in response', () => {
@@ -13,7 +13,7 @@ describe('response mapping', () => {
 
         const response = errorResponse(ssn);
 
-        expect(aktøridlookup._mapResponse(response, ssn)).rejects.toEqual('AktørId not found');
+        expect(sut._mapToAktørId(response, ssn)).rejects.toEqual('AktørId not found');
     });
 
     const okResponse = (ssn, aktørId) => ({
@@ -38,6 +38,6 @@ describe('identifier masking', () => {
     test('obfuscates input', () => {
         const input = '01019512345';
         const result = '0101****345';
-        expect(aktøridlookup._maskIdentifier(input)).toEqual(result);
+        expect(sut._maskIdentifier(input)).toEqual(result);
     });
 });

--- a/src/server/aktørid/aktøridlookup.test.js
+++ b/src/server/aktørid/aktøridlookup.test.js
@@ -1,36 +1,73 @@
 const sut = require('./aktøridlookup');
+const requestMock = require('request-promise-native');
 
-describe('response mapping', () => {
-    test('maps OK response correctly', () => {
-        const ssn = '140819';
-        const aktørId = '1000036876618';
+describe('calling Aktørregisteret', () => {
+    const stsClient = {
+        hentAccessToken: () => Promise.resolve()
+    };
+    const config = {
+        aktoerregisterUrl: ''
+    };
+    sut.init(stsClient, config);
 
-        expect(sut._mapToAktørId(okResponse(ssn, aktørId), ssn)).resolves.toEqual(aktørId);
+    test('hentAktørId works', async () => {
+        const nnin = '123';
+        const expectedAktørId = '456';
+
+        requestMock.prepareAktørregisteretResponse({
+            [nnin]: {
+                identer: [
+                    {
+                        identgruppe: 'AktoerId',
+                        ident: expectedAktørId
+                    }
+                ]
+            }
+        });
+
+        const resultingAktørId = await sut.hentAktørId(nnin);
+        expect(resultingAktørId).toEqual(expectedAktørId);
     });
 
-    test('rejects on error in response', () => {
-        const ssn = '140819';
+    test('hentFnr works', async () => {
+        const aktørId = '456';
+        const expectedNnin = '123';
 
-        const response = errorResponse(ssn);
+        requestMock.prepareAktørregisteretResponse({
+            [aktørId]: {
+                identer: [
+                    {
+                        identgruppe: 'NorskIdent',
+                        ident: expectedNnin
+                    }
+                ]
+            }
+        });
 
-        expect(sut._mapToAktørId(response, ssn)).rejects.toEqual('AktørId not found');
+        const resultingNnin = await sut.hentFnr(aktørId);
+        expect(resultingNnin).toEqual(expectedNnin);
     });
 
-    const okResponse = (ssn, aktørId) => ({
-        [ssn]: {
-            identer: [
-                {
-                    identgruppe: 'AktoerId',
-                    ident: aktørId
-                }
-            ]
-        }
+    test('hentAktørId rejects on error in response', () => {
+        const aktørId = '123';
+        requestMock.prepareAktørregisteretResponse({
+            [aktørId]: {
+                feilmelding: 'uh-oh'
+            }
+        });
+
+        expect(sut.hentAktørId(aktørId)).rejects.toEqual('AktørId not found');
     });
 
-    const errorResponse = ssn => ({
-        [ssn]: {
-            feilmelding: 'uh-oh'
-        }
+    test('hentFnr rejects on error in response', () => {
+        const nnin = '456';
+        requestMock.prepareAktørregisteretResponse({
+            [nnin]: {
+                feilmelding: 'uh-oh'
+            }
+        });
+
+        expect(sut.hentFnr(nnin)).rejects.toEqual('NNIN not found');
     });
 });
 

--- a/src/server/auth/stsclient.test.js
+++ b/src/server/auth/stsclient.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-jest.mock('request-promise-native');
-
 const stsclient = require('./stsclient');
 
 const validCreds = {

--- a/src/server/person/personlookup.test.js
+++ b/src/server/person/personlookup.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-jest.mock('request-promise-native');
-
 const personLookup = require('./personlookup');
 
 const expectedPerson = {


### PR DESCRIPTION
If the search was performed using aktør-ID, look up NNIN from
Aktørregisteret, otherwise just return and display the submitted NNIN.


--

Jeg skal slå sammen de to identiske kallene til Aktørregisteret, de trenger ikke være duplisert.