### PR TITLE
Provide options for express-session

### DIFF
--- a/src/server/sessionstore.js
+++ b/src/server/sessionstore.js
@@ -20,6 +20,8 @@ const createRedisSession = config => {
     return expressSession({
         secret: config.server.sessionSecret,
         ttl: 43200, // 12 hours
+        saveUninitialized: false,
+        resave: false,
         store: new redisStore({
             client: redis.createClient({
                 host: config.redis.host,


### PR DESCRIPTION
These are going to change default values in the future and have been
deprecated, and this is logged to the console on startup. Might as well
take control over their values anyway.

The resave option means whether express-session should save the session
to the store even if it did not change during the request, to avoid the
stored session to invalidate due to timeout (store timeout, not session
timeout). Redis updates the TTL on read, so we do not need
express-session to do it.

The saveUninitialized option means whether new, unchanged sessions
should be stored in the store. I do not think we need this.