### PR TITLE
Feilhåndtering routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "dev-express": "NODE_ENV=development npm run start-express",
         "oppgulp": "nodemon --watch src/server --exec 'npm run dev-express'",
         "mock-s3": "docker-compose --file __mocks__/s3-docker-compose.yaml up",
-        "build": "npm run clean:dist && npm run test && parcel build src/client/index.html --out-dir dist/client --public-url ./ --no-source-maps",
+        "build": "npm run clean:dist && npm run test && parcel build src/client/index.html --out-dir dist/client --public-url /static --no-source-maps",
         "build-server": "$(npm bin)/babel --config-file ./babel-server.config.json src/server --out-dir dist/server",
         "clean:dist": "rimraf dist",
         "prettier": "prettier --write \"src/**/*.{jsx,js,css}\"",

--- a/src/client/io/http.js
+++ b/src/client/io/http.js
@@ -6,7 +6,7 @@ export const ResponseError = (message, statusCode) => ({
 });
 
 /* eslint-disable no-undef */
-const baseUrl = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+const baseUrl = (process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '') + '/api';
 /* eslint-enable */
 
 const getData = async response => {
@@ -17,8 +17,19 @@ const getData = async response => {
     }
 };
 
+const ensureAcceptHeader = (options = {}) => {
+    const acceptHeader = {
+        Accept: 'application/json'
+    };
+    if (!options?.headers) {
+        return { ...options, headers: acceptHeader };
+    } else if (!options.headers.Accept || !options.headers.accept) {
+        return { ...options, headers: { ...acceptHeader, ...options.headers } };
+    }
+};
+
 const get = async (url, options) => {
-    const response = await fetch(url, options);
+    const response = await fetch(url, ensureAcceptHeader(options));
 
     if (response.status >= 400) {
         throw ResponseError(response.statusText, response.status);

--- a/src/server/behandlinger/behandlingerroutes.js
+++ b/src/server/behandlinger/behandlingerroutes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const router = require('express').Router();
 const { log } = require('../logging');
 const mapping = require('./mapping');
 const api = require('./behandlingerlookup');
@@ -10,10 +11,14 @@ const { nameFrom } = require('../auth/authsupport');
 
 const personIdHeaderName = 'nav-person-id';
 
-const setup = ({ app, stsclient, config, path }) => {
+const setup = ({ stsclient, config }) => {
     aktøridlookup.init(stsclient, config);
+    routes({ router });
+    return router;
+};
 
-    app.get(`${path}/behandlinger/`, async (req, res) => {
+const routes = ({ router }) => {
+    router.get('/', async (req, res) => {
         const personId = req.headers[personIdHeaderName];
         if (!personId) {
             log(
@@ -75,7 +80,7 @@ const setup = ({ app, stsclient, config, path }) => {
             });
     });
 
-    app.get(`${path}/behandlinger/periode/:fom/:tom`, (req, res) => {
+    router.get('/periode/:fom/:tom', (req, res) => {
         if (process.env.NODE_ENV === 'development') {
             const filename = 'behandlinger.json';
             fs.readFile(`__mock-data__/${filename}`, (err, data) => {

--- a/src/server/behandlinger/behandlingerroutes.js
+++ b/src/server/behandlinger/behandlingerroutes.js
@@ -10,10 +10,10 @@ const { nameFrom } = require('../auth/authsupport');
 
 const personIdHeaderName = 'nav-person-id';
 
-const setup = ({ app, stsclient, config }) => {
+const setup = ({ app, stsclient, config, path }) => {
     aktøridlookup.init(stsclient, config);
 
-    app.get('/behandlinger/', async (req, res) => {
+    app.get(`${path}/behandlinger/`, async (req, res) => {
         const personId = req.headers[personIdHeaderName];
         if (!personId) {
             log(
@@ -75,7 +75,7 @@ const setup = ({ app, stsclient, config }) => {
             });
     });
 
-    app.get('/behandlinger/periode/:fom/:tom', (req, res) => {
+    app.get(`${path}/behandlinger/periode/:fom/:tom`, (req, res) => {
         if (process.env.NODE_ENV === 'development') {
             const filename = 'behandlinger.json';
             fs.readFile(`__mock-data__/${filename}`, (err, data) => {

--- a/src/server/feedback/feedbackroutes.js
+++ b/src/server/feedback/feedbackroutes.js
@@ -8,22 +8,13 @@ const { excludeOlderFeedback, isInvalid, parseDate, prepareCsvFeedback } = requi
 let counter = null;
 
 const setup = (app, config, instrumentation) => {
+    routes({ app, path: '/api' });
     counter = instrumentation.feedbackCounter();
-    return new Promise((resolve, reject) => {
-        storage
-            .init(config.s3url, config.s3AccessKey, config.s3SecretKey)
-            .then(() => {
-                routes(app);
-                resolve();
-            })
-            .catch(err => {
-                reject(err);
-            });
-    });
+    return storage.init(config.s3url, config.s3AccessKey, config.s3SecretKey);
 };
 
-const routes = app => {
-    app.get('/feedback/:behandlingsId', (req, res) => {
+const routes = ({ app, path }) => {
+    app.get(`${path}/feedback/:behandlingsId`, (req, res) => {
         const behandlingsId = req.params.behandlingsId;
 
         storage
@@ -40,7 +31,7 @@ const routes = app => {
             });
     });
 
-    app.get('/feedback', async (req, res) => {
+    app.get(`${path}/feedback`, async (req, res) => {
         const date = parseDate(req.query.fraogmed);
 
         storage
@@ -62,7 +53,7 @@ const routes = app => {
             });
     });
 
-    app.put('/feedback', (req, res) => {
+    app.put(`${path}/feedback`, (req, res) => {
         log(`Storing feedback from IP address ${ipAddressFromRequest(req)}`);
         if (isInvalid(req)) {
             log(`Rejecting feedback due to validation error`);

--- a/src/server/person/personroutes.js
+++ b/src/server/person/personroutes.js
@@ -9,7 +9,7 @@ const setup = (app, stsclient) => {
 };
 
 const routes = app => {
-    app.get('/person/:aktorId', (req, res) => {
+    app.get('/api/person/:aktorId', (req, res) => {
         if (process.env.NODE_ENV === 'development') {
             const response =
                 req.params.aktorId === '10000000000001'

--- a/src/server/person/personroutes.js
+++ b/src/server/person/personroutes.js
@@ -2,14 +2,16 @@
 
 const personLookup = require('./personlookup');
 const personMapping = require('./personmapping');
+const router = require('express').Router();
 
-const setup = (app, stsclient) => {
+const setup = stsclient => {
     personLookup.init(stsclient);
-    routes(app);
+    routes(router);
+    return router;
 };
 
 const routes = app => {
-    app.get('/api/person/:aktorId', (req, res) => {
+    app.get('/:aktorId', (req, res) => {
         if (process.env.NODE_ENV === 'development') {
             const response =
                 req.params.aktorId === '10000000000001'
@@ -32,5 +34,5 @@ const routes = app => {
 };
 
 module.exports = {
-    setup: setup
+    setup
 };

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -105,27 +105,17 @@ app.use('/*', (req, res, next) => {
     }
 });
 
-person.setup(app, stsclient);
-feedback
-    .setup(app, config.s3, instrumentation)
-    .then(() => {
-        log(`Feedback storage at ${config.s3.s3url}`);
-    })
-    .catch(err => {
-        log(
-            `Failed to setup feedback storage: ${err}. Routes for storing and retrieving feedback will not work, as setup will not be retried.`
-        );
-    });
+app.use('/api/person', person.setup(stsclient));
+app.use('/api/feedback', feedback.setup({ config: config.s3, instrumentation }));
+app.use('/api/behandlinger', behandlinger.setup({ stsclient, config: config.nav }));
 
-behandlinger.setup({ app, stsclient, config: config.nav, path: '/api' });
 app.get('/*', (req, res, next) => {
     if (!req.accepts('html') && /\/api/.test(req.url)) {
-        console.debug(`Received a request for '${req.url}', which didn't match a route`);
+        console.debug(`Received a non-HTML request for '${req.url}', which didn't match a route`);
         res.sendStatus(404);
         return;
-    } else {
-        next();
     }
+    next();
 });
 
 // At the time of writing this comment, the setup of the static 'routes' has to be done in a particular order.


### PR DESCRIPTION
Fra commit-meldinger:

The app is now available on root URL, the REST API is available on /api
and the JS and CSS bundles are available on /static.

* Add error handling for when an API request, for some reason, does not
match any routes - return 404 instead of index.html.

Due to timing issues the error handling of setting up the S3 connection
was changed, from not defining the feedback routes if S3 is not
available to always defining the routes, and just let them fail with 500
if S3 is not available. It was deemed more natural to let the behaviour
of the API change instead of the structure of the API in failure modes.

The timing issue: when waiting for the S3 promise to resolve before
setting up the routes, the static routes would be defined earlier, thus
making the feedback routes unreachable. I later discovered that one can
get around this issue by adding the router ('app.use(<url>, router)')
before adding the static routes, and subsequently define the actual
routes on the router ('router.get(<url>, <handler>)'), but 500 is a
better error code than 404 for the error situation.