### PR TITLE
Do not try processing empty result

### DIFF
--- a/src/client/context/BehandlingerContext.js
+++ b/src/client/context/BehandlingerContext.js
@@ -38,9 +38,10 @@ export const BehandlingerProvider = ({ children }) => {
 
     const fetchBehandlingerMedPersoninfo = async () => {
         const alleBehandlinger = await fetchAlleBehandlinger();
-        const behandlingerMedPersoninfo = await hentNavnForBehandlinger(alleBehandlinger);
-
-        setBehandlinger(behandlingerMedPersoninfo);
+        if (alleBehandlinger !== undefined) {
+            const behandlingerMedPersoninfo = await hentNavnForBehandlinger(alleBehandlinger);
+            setBehandlinger(behandlingerMedPersoninfo);
+        }
         setValgtBehandling(undefined);
     };
 


### PR DESCRIPTION
When no cases were returned when fetching, we don't need to try fetching person info. This
avoids dereferencing an undefined variable.