### PR TITLE
Support reloading the page

### DIFF
--- a/src/client/components/CaseMenu/CaseMenu.jsx
+++ b/src/client/components/CaseMenu/CaseMenu.jsx
@@ -6,7 +6,7 @@ import { toDate } from '../../utils/date';
 import { Normaltekst } from 'nav-frontend-typografi';
 import './CaseMenu.less';
 
-const CaseMenu = ({ behandlinger, behandling, setValgtBehandling }) => {
+const CaseMenu = ({ behandlinger, behandling, onSelectItem }) => {
     const { arbeidsgiver, fom, tom } = behandling.originalSøknad;
     const { sykmeldingsgrad } = behandling.periode;
     const behandlingMapper = behandling => ({
@@ -25,7 +25,7 @@ const CaseMenu = ({ behandlinger, behandling, setValgtBehandling }) => {
                     className="CasePicker"
                     items={cases}
                     currentItem={currentCase}
-                    onChange={setValgtBehandling}
+                    onSelectItem={onSelectItem}
                     itemLabel={caseLabel}
                 />
             </div>
@@ -44,7 +44,7 @@ const CaseMenu = ({ behandlinger, behandling, setValgtBehandling }) => {
 CaseMenu.propTypes = {
     behandlinger: PropTypes.arrayOf(PropTypes.any).isRequired,
     behandling: PropTypes.any,
-    setValgtBehandling: PropTypes.func.isRequired
+    onSelectItem: PropTypes.func.isRequired
 };
 
 export default CaseMenu;

--- a/src/client/components/LeftMenu/LeftMenu.jsx
+++ b/src/client/components/LeftMenu/LeftMenu.jsx
@@ -4,14 +4,14 @@ import CaseMenu from '../CaseMenu/CaseMenu';
 import PropTypes from 'prop-types';
 import './LeftMenu.less';
 
-const LeftMenu = ({ behandlinger, behandling, setValgtBehandling }) => {
+const LeftMenu = ({ behandlinger, behandling, onSelectItem }) => {
     return (
         <div className="LeftMenu">
             {behandling && (
                 <CaseMenu
                     behandlinger={behandlinger}
                     behandling={behandling}
-                    setValgtBehandling={setValgtBehandling}
+                    onSelectItem={onSelectItem}
                 />
             )}
             <Nav active={behandling !== undefined} />
@@ -22,7 +22,7 @@ const LeftMenu = ({ behandlinger, behandling, setValgtBehandling }) => {
 LeftMenu.propTypes = {
     behandlinger: PropTypes.arrayOf(PropTypes.any).isRequired,
     behandling: PropTypes.any,
-    setValgtBehandling: PropTypes.func.isRequired
+    onSelectItem: PropTypes.func.isRequired
 };
 
 export default LeftMenu;

--- a/src/client/components/MainContentWrapper/MainContentWrapper.jsx
+++ b/src/client/components/MainContentWrapper/MainContentWrapper.jsx
@@ -14,7 +14,7 @@ import { withBehandlingContext } from '../../context/BehandlingerContext';
 import './MainContentWrapper.css';
 
 const MainContentWrapper = withBehandlingContext(
-    ({ behandlinger, behandling, userMustSelectBehandling, setValgtBehandling }) => {
+    ({ behandlinger, behandling, userMustSelectBehandling, velgBehandling }) => {
         const [modalOpen, setModalOpen] = useState(false);
 
         useEffect(() => {
@@ -23,9 +23,9 @@ const MainContentWrapper = withBehandlingContext(
             }
         }, [userMustSelectBehandling]);
 
-        const velgBehandling = behandling => {
+        const lukkModalOgVelgBehandling = behandling => {
             setModalOpen(false);
-            setValgtBehandling(behandling);
+            velgBehandling(behandling);
         };
 
         return (
@@ -34,13 +34,13 @@ const MainContentWrapper = withBehandlingContext(
                     <VelgBehandlingModal
                         setModalOpen={setModalOpen}
                         behandlinger={behandlinger}
-                        velgBehandling={velgBehandling}
+                        onSelectItem={lukkModalOgVelgBehandling}
                     />
                 )}
                 <LeftMenu
                     behandling={behandling}
                     behandlinger={behandlinger}
-                    setValgtBehandling={setValgtBehandling}
+                    onSelectItem={lukkModalOgVelgBehandling}
                 />
                 {behandling ? (
                     <div className="main-content">

--- a/src/client/components/MainContentWrapper/MainContentWrapper.jsx
+++ b/src/client/components/MainContentWrapper/MainContentWrapper.jsx
@@ -14,14 +14,14 @@ import { withBehandlingContext } from '../../context/BehandlingerContext';
 import './MainContentWrapper.css';
 
 const MainContentWrapper = withBehandlingContext(
-    ({ behandlinger, behandling, setValgtBehandling }) => {
+    ({ behandlinger, behandling, userMustSelectBehandling, setValgtBehandling }) => {
         const [modalOpen, setModalOpen] = useState(false);
 
         useEffect(() => {
-            if (behandling === undefined && behandlinger?.length > 1) {
+            if (userMustSelectBehandling) {
                 setModalOpen(true);
             }
-        }, [behandlinger, behandling]);
+        }, [userMustSelectBehandling]);
 
         const velgBehandling = behandling => {
             setModalOpen(false);

--- a/src/client/components/MainContentWrapper/MainContentWrapper.test.js
+++ b/src/client/components/MainContentWrapper/MainContentWrapper.test.js
@@ -57,7 +57,7 @@ describe('MainContentWrapper', () => {
     it('render modal when no behandling is chosen', () => {
         const { getByText, container } = render(
             <MemoryRouter>
-                <MainContentWrapper {...wrapperProps} />
+                <MainContentWrapper {...wrapperProps} userMustSelectBehandling={true} />
             </MemoryRouter>
         );
         expect(
@@ -66,11 +66,11 @@ describe('MainContentWrapper', () => {
         expect(container.querySelector('.main-content')).toBe(null);
     });
 
-    it('doesnt render modal when behandling is chosen', () => {
+    it('does not render modal when behandling is chosen', () => {
         const { container } = render(
             <MainContentWrapper {...wrapperProps} behandling={behandling1} />
         );
-        expect(container.querySelector('.main-content')).toBeDefined();
+        expect(container.querySelector('.main-content')).toBeTruthy();
     });
 
     it('render empty state view when there are no behandlinger', () => {

--- a/src/client/components/MainContentWrapper/MainContentWrapper.test.js
+++ b/src/client/components/MainContentWrapper/MainContentWrapper.test.js
@@ -19,7 +19,7 @@ const wrapperProps = {
         behandling1,
         { behandlingsId: '456', originalSøknad: { fom: '2019-06-10', tom: '2019-06-20' } }
     ],
-    setValgtBehandling: jest.fn(),
+    velgBehandling: jest.fn(),
     behandling: undefined
 };
 

--- a/src/client/components/MainContentWrapper/VelgBehandlingModal.jsx
+++ b/src/client/components/MainContentWrapper/VelgBehandlingModal.jsx
@@ -8,7 +8,7 @@ import { toDate } from '../../utils/date';
 
 document && document.getElementById('#root') && Modal.setAppElement('#root');
 
-const VelgBehandlingModal = ({ setModalOpen, behandlinger, velgBehandling }) => (
+const VelgBehandlingModal = ({ setModalOpen, behandlinger, onSelectItem }) => (
     <Modal onRequestClose={() => setModalOpen(false)} contentLabel="Velg behandling" isOpen={true}>
         <div className="VelgBehandlingModal">
             <Undertittel>Velg sak</Undertittel>
@@ -22,7 +22,7 @@ const VelgBehandlingModal = ({ setModalOpen, behandlinger, velgBehandling }) => 
                     <li key={behandling.behandlingsId}>
                         <Normaltekst>{toDate(behandling.originalSøknad.fom)}</Normaltekst>
                         <Normaltekst>{toDate(behandling.originalSøknad.tom)}</Normaltekst>
-                        <Knapp onClick={() => velgBehandling(behandling)}>Velg</Knapp>
+                        <Knapp onClick={() => onSelectItem(behandling)}>Velg</Knapp>
                     </li>
                 ))}
             </ul>
@@ -32,7 +32,7 @@ const VelgBehandlingModal = ({ setModalOpen, behandlinger, velgBehandling }) => 
 
 VelgBehandlingModal.propTypes = {
     behandlinger: PropTypes.arrayOf(PropTypes.any).isRequired,
-    velgBehandling: PropTypes.func.isRequired,
+    onSelectItem: PropTypes.func.isRequired,
     setModalOpen: PropTypes.func.isRequired
 };
 

--- a/src/client/components/Picker/Picker.jsx
+++ b/src/client/components/Picker/Picker.jsx
@@ -5,7 +5,7 @@ import { NedChevron } from 'nav-frontend-chevron';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import './Picker.less';
 
-const Picker = ({ items, className, currentItem, onChange, itemLabel }) => {
+const Picker = ({ items, className, currentItem, onSelectItem, itemLabel }) => {
     const [showPopup, setShowPopup] = useState(false);
     const popupRef = useRef(null);
 
@@ -28,7 +28,7 @@ const Picker = ({ items, className, currentItem, onChange, itemLabel }) => {
                         <li
                             key={`popup-item-${i}`}
                             role="option"
-                            onClick={() => onChange(item)}
+                            onClick={() => onSelectItem(item)}
                             tabIndex={0}
                             aria-selected={currentItem.behandlingsId === item.behandlingsId}
                         >
@@ -48,7 +48,7 @@ Picker.propTypes = {
     items: PropTypes.arrayOf(PropTypes.any).isRequired,
     className: PropTypes.string,
     currentItem: PropTypes.any,
-    onChange: PropTypes.func.isRequired,
+    onSelectItem: PropTypes.func.isRequired,
     itemLabel: PropTypes.func.isRequired
 };
 

--- a/src/client/context/BehandlingerContext.js
+++ b/src/client/context/BehandlingerContext.js
@@ -15,7 +15,7 @@ export const withBehandlingContext = Component => {
             <Component
                 behandlinger={behandlinger}
                 behandling={behandlingerCtx.valgtBehandling}
-                setValgtBehandling={behandlingerCtx.setValgtBehandling}
+                velgBehandling={behandlingerCtx.velgBehandling}
                 userMustSelectBehandling={behandlingerCtx.userMustSelectBehandling}
                 fnr={behandlingerCtx.fnr}
                 fetchAlleBehandlinger={behandlingerCtx.fetchBehandlingerMedPersoninfo}
@@ -160,7 +160,7 @@ export const BehandlingerProvider = ({ children }) => {
             value={{
                 state: { behandlinger },
                 setBehandlinger,
-                setValgtBehandling: velgBehandling,
+                velgBehandling,
                 valgtBehandling,
                 fetchBehandlinger,
                 userMustSelectBehandling,

--- a/src/client/context/BehandlingerContext.js
+++ b/src/client/context/BehandlingerContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { behandlingerFor, behandlingerIPeriode, getPerson } from '../io/http';
 import { useSessionStorage } from '../hooks/useSessionStorage';
@@ -16,6 +16,7 @@ export const withBehandlingContext = Component => {
                 behandlinger={behandlinger}
                 behandling={behandlingerCtx.valgtBehandling}
                 setValgtBehandling={behandlingerCtx.setValgtBehandling}
+                userMustSelectBehandling={behandlingerCtx.userMustSelectBehandling}
                 fnr={behandlingerCtx.fnr}
                 fetchAlleBehandlinger={behandlingerCtx.fetchBehandlingerMedPersoninfo}
                 {...props}
@@ -28,24 +29,32 @@ export const BehandlingerProvider = ({ children }) => {
     const [behandlinger, setBehandlinger] = useSessionStorage('behandlinger', []);
     const [fnr, setFnr] = useState(undefined);
     const [valgtBehandling, setValgtBehandling] = useState(undefined);
+    const [lastSelectedBehandling, setLastSelectedBehandling] = useSessionStorage(
+        'last-selected-behandling-id',
+        undefined
+    );
+    const [userMustSelectBehandling, setUserMustSelectBehandling] = useState(false);
 
-    const velgBehandling = (behandling, history) => {
+    const velgBehandling = async behandling => {
         const valgtBehandling = behandlinger.find(
             b => b.behandlingsId === behandling?.behandlingsId
         );
-        if (valgtBehandling && !valgtBehandling.avklarteVerdier) {
-            fetchBehandlinger(
+        if (valgtBehandling && !valgtBehandling.sykepengeberegning) {
+            await fetchBehandlinger(
                 valgtBehandling.originalSøknad.aktorId,
-                valgtBehandling.behandlingsId,
-                history
+                valgtBehandling.behandlingsId
             );
         } else {
             setValgtBehandling(valgtBehandling);
-            if (history) {
-                history.push('/sykdomsvilkår');
-            }
         }
+        setLastSelectedBehandling(valgtBehandling?.behandlingsId);
     };
+
+    useEffect(() => {
+        if (lastSelectedBehandling !== undefined) {
+            velgBehandling({ behandlingsId: lastSelectedBehandling });
+        }
+    }, [lastSelectedBehandling]);
 
     const fetchBehandlingerMedPersoninfo = async () => {
         setValgtBehandling(undefined);
@@ -112,21 +121,26 @@ export const BehandlingerProvider = ({ children }) => {
             });
     };
 
-    const fetchBehandlinger = (value, behandlingsId, history) => {
+    const fetchBehandlinger = (value, behandlingsId) => {
+        setUserMustSelectBehandling(false);
         return behandlingerFor(value)
             .then(response => {
                 const { behandlinger } = response.data;
                 setFnr(response.data.fnr);
                 setBehandlinger(behandlinger);
                 if (!behandlingsId) {
+                    if (behandlinger?.length === 1) {
+                        setLastSelectedBehandling(behandlinger[0].behandlingsId);
+                    } else if (behandlinger.length > 1) {
+                        setLastSelectedBehandling(null);
+                        setUserMustSelectBehandling(true);
+                    }
+
                     setValgtBehandling(behandlinger?.length !== 1 ? undefined : behandlinger[0]);
                 } else {
                     setValgtBehandling(
                         behandlinger.find(behandling => behandling.behandlingsId === behandlingsId)
                     );
-                }
-                if (history) {
-                    history.push('/sykdomsvilkår');
                 }
                 return { behandlinger };
             })
@@ -145,10 +159,11 @@ export const BehandlingerProvider = ({ children }) => {
         <BehandlingerContext.Provider
             value={{
                 state: { behandlinger },
-                setBehandlinger: setBehandlinger,
+                setBehandlinger,
                 setValgtBehandling: velgBehandling,
                 valgtBehandling,
                 fetchBehandlinger,
+                userMustSelectBehandling,
                 fnr,
                 fetchBehandlingerMedPersoninfo,
                 error,

--- a/src/client/routes/Oversikt/Oversikt.jsx
+++ b/src/client/routes/Oversikt/Oversikt.jsx
@@ -48,8 +48,9 @@ const Oversikt = ({ history }) => {
         [innrapportering.feedback, behandlinger]
     );
 
-    const velgBehandling = behandling => {
-        setValgtBehandling(behandling, history);
+    const velgBehandling = async behandling => {
+        await setValgtBehandling(behandling);
+        history.push('/sykdomsvilkår');
     };
 
     return (

--- a/src/client/routes/Oversikt/Oversikt.jsx
+++ b/src/client/routes/Oversikt/Oversikt.jsx
@@ -15,7 +15,7 @@ const Oversikt = ({ history }) => {
     const behandlingerCtx = useContext(BehandlingerContext);
     const innrapportering = useContext(InnrapporteringContext);
 
-    const { fetchBehandlingerMedPersoninfo, setValgtBehandling } = behandlingerCtx;
+    const { fetchBehandlingerMedPersoninfo, velgBehandling } = behandlingerCtx;
     const behandlinger = behandlingerCtx.state.behandlinger;
 
     useEffect(() => {
@@ -48,8 +48,8 @@ const Oversikt = ({ history }) => {
         [innrapportering.feedback, behandlinger]
     );
 
-    const velgBehandling = async behandling => {
-        await setValgtBehandling(behandling);
+    const velgBehandlingAndNavigate = async behandling => {
+        await velgBehandling(behandling);
         history.push('/sykdomsvilkår');
     };
 
@@ -69,7 +69,7 @@ const Oversikt = ({ history }) => {
                         {ubehandledeSaker.map(behandling => (
                             <tr key={behandling.behandlingsId}>
                                 <td>
-                                    <Lenke onClick={() => velgBehandling(behandling)}>
+                                    <Lenke onClick={() => velgBehandlingAndNavigate(behandling)}>
                                         {behandling.personinfo?.navn ??
                                             behandling.originalSøknad.aktorId}
                                     </Lenke>
@@ -92,7 +92,9 @@ const Oversikt = ({ history }) => {
                     </li>
                     {behandledeSaker.map(sak => (
                         <li className="row row--info" key={sak.behandlingsId}>
-                            <Lenke onClick={() => velgBehandling(sak)}>{sak.søkerName}</Lenke>
+                            <Lenke onClick={() => velgBehandlingAndNavigate(sak)}>
+                                {sak.søkerName}
+                            </Lenke>
                             <Normaltekst>{sak.userName}</Normaltekst>
                             <Normaltekst>{toDateAndTime(sak.submittedDate)}</Normaltekst>
                         </li>


### PR DESCRIPTION
Store the ID of the current behandling in session storage, in order to
be able to show the same behandling if the page is reloaded.

In addition to being good web practice to support reload, this helps
when developing, as we no longer need to search for
behandling(er) after Parcel has done some hot reloading of updated code.

This could/should be replaced by putting the ID of the behandling in the
URL.