### PR TITLE
Reuse node_modules from build step instead of reinstalling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-node_modules
 .cache
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ ENV TZ="Europe/Oslo"
 
 WORKDIR /app
 
-COPY package*.json /app/
-RUN npm install
-
-COPY dist/server/ /app/dist/server/
-COPY dist/client/ /app/dist/client/
+COPY node_modules/ node_modules/
+COPY dist/server/ dist/server/
+COPY dist/client/ dist/client/
 
 EXPOSE 3000
 


### PR DESCRIPTION
It should be ok to assume that 'npm install' has just been run when the
docker build is initiated.

We need node_modules at runtime, without it we are getting this error:

Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault'