### PR TITLE
Remove withBehandlingContext-hoc

### DIFF
--- a/src/client/components/MainContentWrapper/MainContentWrapper.jsx
+++ b/src/client/components/MainContentWrapper/MainContentWrapper.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import { Route } from 'react-router-dom';
+import React, { useContext, useEffect, useState } from 'react';
 import PersonBar from '../PersonBar';
 import LeftMenu from '../LeftMenu';
 import Periode from '../../routes/Periode';
@@ -10,54 +9,57 @@ import Sykdomsvilkår from '../../routes/Sykdomsvilkår';
 import Inngangsvilkår from '../../routes/Inngangsvilkår';
 import EmptyStateView from '../EmptyStateView';
 import VelgBehandlingModal from './VelgBehandlingModal';
-import { withBehandlingContext } from '../../context/BehandlingerContext';
+import { Route } from 'react-router-dom';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
 import './MainContentWrapper.css';
 
-const MainContentWrapper = withBehandlingContext(
-    ({ behandlinger, behandling, userMustSelectBehandling, velgBehandling }) => {
-        const [modalOpen, setModalOpen] = useState(false);
+const MainContentWrapper = () => {
+    const { userMustSelectBehandling, velgBehandling, valgtBehandling, state } = useContext(
+        BehandlingerContext
+    );
+    const { behandlinger } = state;
+    const [modalOpen, setModalOpen] = useState(false);
 
-        useEffect(() => {
-            if (userMustSelectBehandling) {
-                setModalOpen(true);
-            }
-        }, [userMustSelectBehandling]);
+    useEffect(() => {
+        if (userMustSelectBehandling) {
+            setModalOpen(true);
+        }
+    }, [userMustSelectBehandling]);
 
-        const lukkModalOgVelgBehandling = behandling => {
-            setModalOpen(false);
-            velgBehandling(behandling);
-        };
+    const lukkModalOgVelgBehandling = valgtBehandling => {
+        setModalOpen(false);
+        velgBehandling(valgtBehandling);
+    };
 
-        return (
-            <div className="page-content">
-                {modalOpen && (
-                    <VelgBehandlingModal
-                        setModalOpen={setModalOpen}
-                        behandlinger={behandlinger}
-                        onSelectItem={lukkModalOgVelgBehandling}
-                    />
-                )}
-                <LeftMenu
-                    behandling={behandling}
+    return (
+        <div className="page-content">
+            {modalOpen && (
+                <VelgBehandlingModal
+                    setModalOpen={setModalOpen}
                     behandlinger={behandlinger}
                     onSelectItem={lukkModalOgVelgBehandling}
                 />
-                {behandling ? (
-                    <div className="main-content">
-                        <PersonBar />
-                        <Route path={'/sykdomsvilkår'} exact component={Sykdomsvilkår} />
-                        <Route path={'/inngangsvilkår'} exact component={Inngangsvilkår} />
-                        <Route path={'/beregning'} exact component={Beregning} />
-                        <Route path={'/periode'} exact component={Periode} />
-                        <Route path={'/utbetaling'} exact component={Utbetaling} />
-                        <Route path={'/oppsummering'} exact component={Oppsummering} />
-                    </div>
-                ) : (
-                    <EmptyStateView />
-                )}
-            </div>
-        );
-    }
-);
+            )}
+            <LeftMenu
+                behandling={valgtBehandling}
+                behandlinger={behandlinger}
+                onSelectItem={lukkModalOgVelgBehandling}
+            />
+            {valgtBehandling ? (
+                <div className="main-content">
+                    <PersonBar />
+                    <Route path={'/sykdomsvilkår'} exact component={Sykdomsvilkår} />
+                    <Route path={'/inngangsvilkår'} exact component={Inngangsvilkår} />
+                    <Route path={'/beregning'} exact component={Beregning} />
+                    <Route path={'/periode'} exact component={Periode} />
+                    <Route path={'/utbetaling'} exact component={Utbetaling} />
+                    <Route path={'/oppsummering'} exact component={Oppsummering} />
+                </div>
+            ) : (
+                <EmptyStateView />
+            )}
+        </div>
+    );
+};
 
 export default MainContentWrapper;

--- a/src/client/components/MainContentWrapper/MainContentWrapper.test.js
+++ b/src/client/components/MainContentWrapper/MainContentWrapper.test.js
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom/extend-expect';
 import MainContentWrapper from './MainContentWrapper';
 import ReactModal from 'react-modal';
 import { MemoryRouter } from 'react-router-dom';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
 
 ReactModal.setAppElement('*'); // suppresses modal-related test warnings.
 afterEach(cleanup);
@@ -15,21 +16,18 @@ const behandling1 = {
     originalSøknad: { fom: '2019-05-10', tom: '2019-05-20' }
 };
 const wrapperProps = {
-    behandlinger: [
-        behandling1,
-        { behandlingsId: '456', originalSøknad: { fom: '2019-06-10', tom: '2019-06-20' } }
-    ],
+    state: {
+        behandlinger: [
+            behandling1,
+            { behandlingsId: '456', originalSøknad: { fom: '2019-06-10', tom: '2019-06-20' } }
+        ]
+    },
     velgBehandling: jest.fn(),
-    behandling: undefined
+    valgtBehandling: undefined
 };
 
 jest.mock('../PersonBar', () => () => <div />);
 jest.mock('../LeftMenu', () => () => <div />);
-jest.mock('../../context/BehandlingerContext', () => ({
-    withBehandlingContext: jest
-        .fn()
-        .mockImplementation(Component => props => <Component {...props} />)
-}));
 
 jest.mock('nav-frontend-lukknapp-style', () => {
     return {};
@@ -57,7 +55,14 @@ describe('MainContentWrapper', () => {
     it('render modal when no behandling is chosen', () => {
         const { getByText, container } = render(
             <MemoryRouter>
-                <MainContentWrapper {...wrapperProps} userMustSelectBehandling={true} />
+                <BehandlingerContext.Provider
+                    value={{
+                        ...wrapperProps,
+                        userMustSelectBehandling: true
+                    }}
+                >
+                    <MainContentWrapper />
+                </BehandlingerContext.Provider>
             </MemoryRouter>
         );
         expect(
@@ -68,7 +73,14 @@ describe('MainContentWrapper', () => {
 
     it('does not render modal when behandling is chosen', () => {
         const { container } = render(
-            <MainContentWrapper {...wrapperProps} behandling={behandling1} />
+            <BehandlingerContext.Provider
+                value={{
+                    ...wrapperProps,
+                    valgtBehandling: { ...behandling1 }
+                }}
+            >
+                <MainContentWrapper />
+            </BehandlingerContext.Provider>
         );
         expect(container.querySelector('.main-content')).toBeTruthy();
     });
@@ -76,7 +88,16 @@ describe('MainContentWrapper', () => {
     it('render empty state view when there are no behandlinger', () => {
         const { getByText } = render(
             <MemoryRouter>
-                <MainContentWrapper {...wrapperProps} behandlinger={[]} />
+                <BehandlingerContext.Provider
+                    value={{
+                        ...wrapperProps,
+                        state: {
+                            behandlinger: []
+                        }
+                    }}
+                >
+                    <MainContentWrapper />
+                </BehandlingerContext.Provider>
             </MemoryRouter>
         );
         expect(

--- a/src/client/context/BehandlingerContext.js
+++ b/src/client/context/BehandlingerContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { behandlingerFor, behandlingerIPeriode, getPerson } from '../io/http';
 import { useSessionStorage } from '../hooks/useSessionStorage';
@@ -6,24 +6,6 @@ import moment from 'moment';
 
 export const BehandlingerContext = createContext();
 
-export const withBehandlingContext = Component => {
-    return props => {
-        const behandlingerCtx = useContext(BehandlingerContext);
-        const behandlinger = behandlingerCtx.state?.behandlinger ?? [];
-
-        return (
-            <Component
-                behandlinger={behandlinger}
-                behandlingsoversikt={behandlingerCtx.behandlingsoversikt}
-                behandling={behandlingerCtx.valgtBehandling}
-                velgBehandling={behandlingerCtx.velgBehandling}
-                velgBehandlingFraOversikt={behandlingerCtx.velgBehandlingFraOversikt}
-                userMustSelectBehandling={behandlingerCtx.userMustSelectBehandling}
-                {...props}
-            />
-        );
-    };
-};
 export const BehandlingerProvider = ({ children }) => {
     const [error, setError] = useState(undefined);
     const [behandlinger, setBehandlinger] = useSessionStorage('behandlinger', []);

--- a/src/client/context/InnrapporteringContext.js
+++ b/src/client/context/InnrapporteringContext.js
@@ -1,10 +1,10 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
-import { useSessionStorage } from '../hooks/useSessionStorage';
-import { withBehandlingContext } from './BehandlingerContext';
-import { AuthContext } from './AuthContext';
-import { getFeedback, getFeedbackList } from '../io/http';
 import moment from 'moment';
+import PropTypes from 'prop-types';
+import { AuthContext } from './AuthContext';
+import { useSessionStorage } from '../hooks/useSessionStorage';
+import { BehandlingerContext } from './BehandlingerContext';
+import { getFeedback, getFeedbackList } from '../io/http';
 
 export const InnrapporteringContext = createContext({
     uenigheter: [],
@@ -13,137 +13,132 @@ export const InnrapporteringContext = createContext({
     feedback: []
 });
 
-export const InnrapporteringProvider = withBehandlingContext(
-    ({ behandlingsoversikt, behandling, children }) => {
-        const authContext = useContext(AuthContext);
-        const behandlingsId = behandling?.behandlingsId;
-        const [hasSendt, setHasSendt] = useSessionStorage('harSendtUenigheter');
-        const [kommentarer, setKommentarer] = useSessionStorage('kommentarer');
-        const [uenigheter, setUenigheter] = useSessionStorage(`uenigheter-${behandlingsId}`, []);
-        const [godkjent, setGodkjent] = useSessionStorage('godkjent');
-        const [feedback, setFeedback] = useState([]);
+export const InnrapporteringProvider = ({ children }) => {
+    const authContext = useContext(AuthContext);
+    const { valgtBehandling, behandlingsoversikt } = useContext(BehandlingerContext);
+    const behandlingsId = valgtBehandling?.behandlingsId;
+    const [hasSendt, setHasSendt] = useSessionStorage('harSendtUenigheter');
+    const [kommentarer, setKommentarer] = useSessionStorage('kommentarer');
+    const [uenigheter, setUenigheter] = useSessionStorage(`uenigheter-${behandlingsId}`, []);
+    const [godkjent, setGodkjent] = useSessionStorage('godkjent');
+    const [feedback, setFeedback] = useState([]);
 
-        useEffect(() => {
-            if (behandlingsId !== undefined) {
-                const feedbackInList = feedback.find(f => f.key === behandlingsId);
-                if (feedbackInList === undefined) {
-                    fetchFeedback(behandlingsId);
-                } else {
-                    setUenigheter(feedbackInList.value.uenigheter ?? []);
-                    setKommentarer(feedbackInList.value.kommentarer);
-                    setGodkjent(
-                        feedbackInList.value.godkjent ??
-                            !(feedbackInList.value.uenigheter?.length > 0)
-                    );
+    useEffect(() => {
+        if (behandlingsId !== undefined) {
+            const feedbackInList = feedback.find(f => f.key === behandlingsId);
+            if (feedbackInList === undefined) {
+                fetchFeedback(behandlingsId);
+            } else {
+                setUenigheter(feedbackInList.value.uenigheter ?? []);
+                setKommentarer(feedbackInList.value.kommentarer);
+                setGodkjent(
+                    feedbackInList.value.godkjent ?? !(feedbackInList.value.uenigheter?.length > 0)
+                );
+                setHasSendt(true);
+            }
+        }
+    }, [behandlingsId, feedback]);
+
+    useEffect(() => {
+        if (
+            behandlingsoversikt.length > 0 &&
+            behandlingsId === undefined &&
+            feedback.length === 0
+        ) {
+            const behandlingIdList = behandlingsoversikt.map(b => b.behandlingsId);
+            fetchFeedbackList(behandlingIdList);
+        }
+    }, [behandlingsoversikt, behandlingsId, feedback.length]);
+
+    const fetchFeedback = behandlingsId => {
+        return getFeedback(behandlingsId)
+            .then(response => {
+                if (response.status === 200) {
+                    setUenigheter(response.data.uenigheter ?? []);
+                    setKommentarer(response.data.kommentarer);
+                    setGodkjent(response.data.godkjent ?? !(response.data.uenigheter?.length > 0));
                     setHasSendt(true);
                 }
-            }
-        }, [behandlingsId, feedback]);
+            })
+            .catch(err => {
+                console.log(err); // eslint-disable-line no-console
+            });
+    };
 
-        useEffect(() => {
-            if (
-                behandlingsoversikt.length > 0 &&
-                behandlingsId === undefined &&
-                feedback.length === 0
-            ) {
-                const behandlingIdList = behandlingsoversikt.map(b => b.behandlingsId);
-                fetchFeedbackList(behandlingIdList);
-            }
-        }, [behandlingsoversikt, behandlingsId, feedback.length]);
+    const fetchFeedbackList = behandlingsIdList => {
+        return getFeedbackList(behandlingsIdList)
+            .then(response => {
+                if (response.status === 200) {
+                    setFeedback(response.data);
+                }
+            })
+            .catch(err => {
+                console.log(err); // eslint-disable-line no-console
+            });
+    };
 
-        const fetchFeedback = behandlingsId => {
-            return getFeedback(behandlingsId)
-                .then(response => {
-                    if (response.status === 200) {
-                        setUenigheter(response.data.uenigheter ?? []);
-                        setKommentarer(response.data.kommentarer);
-                        setGodkjent(
-                            response.data.godkjent ?? !(response.data.uenigheter?.length > 0)
-                        );
-                        setHasSendt(true);
-                    }
-                })
-                .catch(err => {
-                    console.log(err); // eslint-disable-line no-console
-                });
-        };
+    const removeUenighet = id => {
+        setHasSendt(false);
+        const filteredUenigheter = uenigheter.filter(uenighet => uenighet.id !== id);
+        setUenigheter(filteredUenigheter);
 
-        const fetchFeedbackList = behandlingsIdList => {
-            return getFeedbackList(behandlingsIdList)
-                .then(response => {
-                    if (response.status === 200) {
-                        setFeedback(response.data);
-                    }
-                })
-                .catch(err => {
-                    console.log(err); // eslint-disable-line no-console
-                });
-        };
+        if (filteredUenigheter.length === 0) {
+            setGodkjent(true);
+        }
+    };
 
-        const removeUenighet = id => {
-            setHasSendt(false);
-            const filteredUenigheter = uenigheter.filter(uenighet => uenighet.id !== id);
-            setUenigheter(filteredUenigheter);
+    const addUenighet = (id, label, items) => {
+        setHasSendt(false);
+        setGodkjent(false);
+        if (!uenigheter.find(uenighet => uenighet.id === id)) {
+            setUenigheter(uenigheter => [
+                ...uenigheter,
+                {
+                    id,
+                    label,
+                    items,
+                    value: '',
+                    userId: {
+                        ident: authContext.authInfo.ident,
+                        email: authContext.authInfo.email
+                    },
+                    date: moment().format()
+                }
+            ]);
+        }
+    };
 
-            if (filteredUenigheter.length === 0) {
-                setGodkjent(true);
-            }
-        };
-
-        const addUenighet = (id, label, items) => {
-            setHasSendt(false);
-            setGodkjent(false);
-            if (!uenigheter.find(uenighet => uenighet.id === id)) {
-                setUenigheter(uenigheter => [
-                    ...uenigheter,
-                    {
-                        id,
-                        label,
-                        items,
-                        value: '',
-                        userId: {
-                            ident: authContext.authInfo.ident,
-                            email: authContext.authInfo.email
-                        },
-                        date: moment().format()
-                    }
-                ]);
-            }
-        };
-
-        const updateUenighet = (id, value) => {
-            setHasSendt(false);
-            setUenigheter(uenigheter =>
-                uenigheter.map(uenighet => (uenighet.id === id ? { ...uenighet, value } : uenighet))
-            );
-        };
-
-        return (
-            <InnrapporteringContext.Provider
-                value={{
-                    uenigheter,
-                    setUenigheter,
-                    removeUenighet,
-                    addUenighet,
-                    updateUenighet,
-                    hasSendt,
-                    setHasSendt,
-                    kommentarer,
-                    godkjent,
-                    setGodkjent,
-                    fetchFeedback,
-                    feedback,
-                    setKommentarer: val => {
-                        setHasSendt(false);
-                        setKommentarer(val);
-                    }
-                }}
-            >
-                {children}
-            </InnrapporteringContext.Provider>
+    const updateUenighet = (id, value) => {
+        setHasSendt(false);
+        setUenigheter(uenigheter =>
+            uenigheter.map(uenighet => (uenighet.id === id ? { ...uenighet, value } : uenighet))
         );
-    }
-);
+    };
+
+    return (
+        <InnrapporteringContext.Provider
+            value={{
+                uenigheter,
+                setUenigheter,
+                removeUenighet,
+                addUenighet,
+                updateUenighet,
+                hasSendt,
+                setHasSendt,
+                kommentarer,
+                godkjent,
+                setGodkjent,
+                feedback,
+                setKommentarer: val => {
+                    setHasSendt(false);
+                    setKommentarer(val);
+                }
+            }}
+        >
+            {children}
+        </InnrapporteringContext.Provider>
+    );
+};
 
 InnrapporteringProvider.propTypes = {
     children: PropTypes.node.isRequired

--- a/src/client/routes/Beregning/Beregning.jsx
+++ b/src/client/routes/Beregning/Beregning.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import IconRow from '../../components/Rows/IconRow';
 import ListRow from '../../components/Rows/ListRow';
 import ItemMapper from '../../datamapping/beregningMapper';
@@ -8,11 +8,12 @@ import SykepengegrunnlagModal from './SykepengegrunnlagModal';
 import { Panel } from 'nav-frontend-paneler';
 import { toKroner } from '../../utils/locale';
 import { Element, Undertittel } from 'nav-frontend-typografi';
-import { withBehandlingContext } from '../../context/BehandlingerContext';
 import { beregningstekster, tekster } from '../../tekster';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
 
-const Beregning = withBehandlingContext(({ behandling }) => {
-    const { sykepengeberegning } = behandling;
+const Beregning = () => {
+    const { valgtBehandling } = useContext(BehandlingerContext);
+    const { sykepengeberegning } = valgtBehandling;
     const [visDetaljerboks, setVisDetaljerboks] = useState(false);
 
     const detaljerKnapp = (
@@ -41,7 +42,7 @@ const Beregning = withBehandlingContext(({ behandling }) => {
             <ListRow
                 label={beregningstekster('aordningen')}
                 labelProp={detaljerKnapp}
-                items={ItemMapper.aordning(behandling.sykepengeberegning)}
+                items={ItemMapper.aordning(valgtBehandling.sykepengeberegning)}
                 bold
             />
             <IconRow
@@ -74,6 +75,6 @@ const Beregning = withBehandlingContext(({ behandling }) => {
             <Navigasjonsknapper previous="/inngangsvilkår" next="/periode" />
         </Panel>
     );
-});
+};
 
 export default Beregning;

--- a/src/client/routes/Inngangsvilkår/Inngangsvilkår.jsx
+++ b/src/client/routes/Inngangsvilkår/Inngangsvilkår.jsx
@@ -1,15 +1,16 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import IconRow from '../../components/Rows/IconRow';
 import ListRow from '../../components/Rows/ListRow';
 import ItemMapper from '../../datamapping/inngangsvilkårMapper';
+import TidligerePerioderModal from './TidligerePerioderModal';
 import { Panel } from 'nav-frontend-paneler';
 import { Undertittel } from 'nav-frontend-typografi';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
 import { inngangsvilkårtekster as tekster } from '../../tekster';
-import { withBehandlingContext } from '../../context/BehandlingerContext';
-import TidligerePerioderModal from './TidligerePerioderModal';
 import NavigationButtons from '../../components/NavigationButtons/NavigationButtons';
 
-const Inngangsvilkår = withBehandlingContext(({ behandling }) => {
+const Inngangsvilkår = () => {
+    const { valgtBehandling } = useContext(BehandlingerContext);
     const [visDetaljerboks, setVisDetaljerboks] = useState(false);
 
     const detaljerKnapp = (
@@ -17,45 +18,46 @@ const Inngangsvilkår = withBehandlingContext(({ behandling }) => {
             Vis detaljer
         </button>
     );
+
     return (
         <Panel border>
             <Undertittel className="panel-tittel">{tekster(`tittel`)}</Undertittel>
             {visDetaljerboks && (
                 <TidligerePerioderModal
-                    perioder={behandling.inngangsvilkår.dagerIgjen.tidligerePerioder}
+                    perioder={valgtBehandling.inngangsvilkår.dagerIgjen.tidligerePerioder}
                     onClose={() => setVisDetaljerboks(false)}
-                    førsteFraværsdag={behandling.inngangsvilkår.dagerIgjen.førsteFraværsdag}
+                    førsteFraværsdag={valgtBehandling.inngangsvilkår.dagerIgjen.førsteFraværsdag}
                 />
             )}
             <IconRow label="Inngangsvilkår oppfylt" bold />
             <ListRow
                 label="Medlemskap"
-                items={ItemMapper.medlemskap(behandling.inngangsvilkår.medlemskap)}
+                items={ItemMapper.medlemskap(valgtBehandling.inngangsvilkår.medlemskap)}
             />
             <ListRow
                 label="Opptjening"
-                items={ItemMapper.opptjening(behandling.inngangsvilkår.opptjening)}
+                items={ItemMapper.opptjening(valgtBehandling.inngangsvilkår.opptjening)}
             />
             <ListRow
                 label="Mer enn 0,5G"
-                items={ItemMapper.merEnn05G(behandling.inngangsvilkår.merEnn05G)}
+                items={ItemMapper.merEnn05G(valgtBehandling.inngangsvilkår.merEnn05G)}
             />
             <ListRow
                 label="Søknadsfrist"
-                items={ItemMapper.søknadsfrist(behandling.inngangsvilkår.søknadsfrist)}
+                items={ItemMapper.søknadsfrist(valgtBehandling.inngangsvilkår.søknadsfrist)}
             />
             <ListRow
                 label="Dager igjen"
                 labelProp={detaljerKnapp}
-                items={ItemMapper.dagerIgjen(behandling.inngangsvilkår.dagerIgjen)}
+                items={ItemMapper.dagerIgjen(valgtBehandling.inngangsvilkår.dagerIgjen)}
             />
             <ListRow
                 label="Under 67 år"
-                items={ItemMapper.under67År(behandling.inngangsvilkår.dagerIgjen)}
+                items={ItemMapper.under67År(valgtBehandling.inngangsvilkår.dagerIgjen)}
             />
             <NavigationButtons previous="/sykdomsvilkår" next="/beregning" />
         </Panel>
     );
-});
+};
 
 export default Inngangsvilkår;

--- a/src/client/routes/Oppsummering/Oppsummering.jsx
+++ b/src/client/routes/Oppsummering/Oppsummering.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import ListItem from '../../components/ListItem';
 import ListSeparator from '../../components/ListSeparator';
 import Innrapportering from './Innrapportering';
@@ -7,33 +7,34 @@ import { Panel } from 'nav-frontend-paneler';
 import { toDate } from '../../utils/date';
 import { toKroner } from '../../utils/locale';
 import { Undertittel } from 'nav-frontend-typografi';
-import { withBehandlingContext } from '../../context/BehandlingerContext';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
 import { oppsummeringstekster, tekster } from '../../tekster';
 import './Oppsummering.less';
 
-const Oppsummering = withBehandlingContext(({ behandling }) => {
+const Oppsummering = () => {
+    const { valgtBehandling } = useContext(BehandlingerContext);
     return (
         <div className="Oppsummering">
             <Panel border>
                 <Undertittel>{oppsummeringstekster('tittel')}</Undertittel>
                 <ListItem
                     label={oppsummeringstekster('sykdomsvilkår')}
-                    value={behandling.oppsummering.sykdomsvilkårErOppfylt}
+                    value={valgtBehandling.oppsummering.sykdomsvilkårErOppfylt}
                 />
                 <ListSeparator type="dotted" />
                 <ListItem
                     label={oppsummeringstekster('inngangsvilkår')}
-                    value={behandling.oppsummering.inngangsvilkårErOppfylt}
+                    value={valgtBehandling.oppsummering.inngangsvilkårErOppfylt}
                 />
                 <ListSeparator type="dotted" />
                 <ListItem
                     label={oppsummeringstekster('arbeidsgiver')}
-                    value={behandling.oppsummering.arbeidsgiver.navn}
+                    value={valgtBehandling.oppsummering.arbeidsgiver.navn}
                     bold
                 />
                 <ListItem
                     label={oppsummeringstekster('orgnr')}
-                    value={behandling.oppsummering.arbeidsgiver.orgnummer}
+                    value={valgtBehandling.oppsummering.arbeidsgiver.orgnummer}
                     bold
                 />
                 <ListItem
@@ -43,58 +44,58 @@ const Oppsummering = withBehandlingContext(({ behandling }) => {
                 />
                 <ListItem
                     label={oppsummeringstekster('betaler')}
-                    value={behandling.oppsummering.betalerArbeidsgiverperiode ? 'Nei' : 'Ja'}
+                    value={valgtBehandling.oppsummering.betalerArbeidsgiverperiode ? 'Nei' : 'Ja'}
                 />
                 <ListItem
                     label={oppsummeringstekster('fordeling')}
-                    value={`${behandling.oppsummering.fordeling}%`}
+                    value={`${valgtBehandling.oppsummering.fordeling}%`}
                 />
                 <ListSeparator type="dotted" />
                 <ListItem
                     label={oppsummeringstekster('sykepengegrunnlag')}
-                    value={`${toKroner(behandling.oppsummering.sykepengegrunnlag)} kr`}
+                    value={`${toKroner(valgtBehandling.oppsummering.sykepengegrunnlag)} kr`}
                 />
                 <ListItem
                     label={oppsummeringstekster('månedsbeløp')}
-                    value={`${toKroner(behandling.oppsummering.månedsbeløp)} kr`}
+                    value={`${toKroner(valgtBehandling.oppsummering.månedsbeløp)} kr`}
                     bold
                 />
                 <ListItem
                     label={oppsummeringstekster('dagsats')}
-                    value={`${toKroner(behandling.oppsummering.dagsats)} kr`}
+                    value={`${toKroner(valgtBehandling.oppsummering.dagsats)} kr`}
                 />
                 <ListSeparator type="dotted" />
                 <ListItem
                     label={oppsummeringstekster('antall_utbetalingsdager')}
-                    value={behandling.oppsummering.antallUtbetalingsdager}
+                    value={valgtBehandling.oppsummering.antallUtbetalingsdager}
                 />
                 <ListItem
                     label={oppsummeringstekster('fom')}
-                    value={toDate(behandling.oppsummering.sykmeldtFraOgMed)}
+                    value={toDate(valgtBehandling.oppsummering.sykmeldtFraOgMed)}
                     bold
                 />
                 <ListItem
                     label={oppsummeringstekster('tom')}
-                    value={toDate(behandling.oppsummering.sykmeldtTilOgMed)}
+                    value={toDate(valgtBehandling.oppsummering.sykmeldtTilOgMed)}
                     bold
                 />
                 <ListItem
                     label={oppsummeringstekster('sykmeldingsgrad')}
-                    value={`${behandling.oppsummering.sykmeldingsgrad}%`}
+                    value={`${valgtBehandling.oppsummering.sykmeldingsgrad}%`}
                     bold
                 />
                 <ListSeparator type="dotted" />
                 <ListItem
                     label={oppsummeringstekster('utbetalesFom')}
-                    value={toDate(behandling.oppsummering.utbetalesFom)}
+                    value={toDate(valgtBehandling.oppsummering.utbetalesFom)}
                 />
                 <ListItem
                     label={oppsummeringstekster('utbetalesTom')}
-                    value={toDate(behandling.oppsummering.utbetalesTom)}
+                    value={toDate(valgtBehandling.oppsummering.utbetalesTom)}
                 />
                 <ListItem
                     label={oppsummeringstekster('utbetaling')}
-                    value={`${toKroner(behandling.oppsummering.utbetaling)} kr`}
+                    value={`${toKroner(valgtBehandling.oppsummering.utbetaling)} kr`}
                 />
                 <ListSeparator type="solid" />
                 <Navigasjonsknapper previous="/utbetaling" />
@@ -104,6 +105,6 @@ const Oppsummering = withBehandlingContext(({ behandling }) => {
             </div>
         </div>
     );
-});
+};
 
 export default Oppsummering;

--- a/src/client/routes/Oppsummering/Uenigheter.jsx
+++ b/src/client/routes/Oppsummering/Uenigheter.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Normaltekst } from 'nav-frontend-typografi';
+import { oppsummeringstekster } from '../../tekster';
+
+const Uenigheter = ({ uenigheter }) => {
+    return (
+        <>
+            <Normaltekst className="Innrapportering__category">Uenigheter</Normaltekst>
+            {uenigheter.length === 0 && (
+                <Normaltekst>{oppsummeringstekster('ingen_uenigheter')}</Normaltekst>
+            )}
+            {uenigheter.map((uenighet, i) => (
+                <Normaltekst key={`uenighet-${i}`} className="Innrapportering__uenighet">
+                    <span>{uenighet.label}:</span>
+                    <span>{uenighet.value}</span>
+                    {!uenighet.value && (
+                        <span className="skjemaelement__feilmelding">
+                            {oppsummeringstekster('oppgi_årsak')}
+                        </span>
+                    )}
+                </Normaltekst>
+            ))}
+        </>
+    );
+};
+
+Uenigheter.propTypes = {
+    uenigheter: PropTypes.arrayOf(PropTypes.any)
+};
+
+export default Uenigheter;

--- a/src/client/routes/Oversikt/Oversikt.jsx
+++ b/src/client/routes/Oversikt/Oversikt.jsx
@@ -12,14 +12,12 @@ import { toDate, toDateAndTime } from '../../utils/date';
 import './Oversikt.less';
 
 const Oversikt = ({ history }) => {
-    const behandlingerCtx = useContext(BehandlingerContext);
-    const innrapportering = useContext(InnrapporteringContext);
-
     const {
         behandlingsoversikt,
         fetchBehandlingsoversiktMedPersoninfo,
         velgBehandlingFraOversikt
-    } = behandlingerCtx;
+    } = useContext(BehandlingerContext);
+    const innrapportering = useContext(InnrapporteringContext);
 
     useEffect(() => {
         fetchBehandlingsoversiktMedPersoninfo();

--- a/src/client/routes/Periode/Periode.jsx
+++ b/src/client/routes/Periode/Periode.jsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import IconRow from '../../components/Rows/IconRow';
 import FormRow from '../../components/Rows/FormRow';
 import ListSeparator from '../../components/ListSeparator/ListSeparator';
 import NavigationButtons from '../../components/NavigationButtons';
-import { Panel } from 'nav-frontend-paneler';
-import { Element, Undertittel } from 'nav-frontend-typografi';
-import { withBehandlingContext } from '../../context/BehandlingerContext';
-import { periodetekster, tekster } from '../../tekster';
-import { toDate } from '../../utils/date';
 import FormRowWithListValues from '../../components/Rows/FormRowWithListValues';
+import { Panel } from 'nav-frontend-paneler';
+import { toDate } from '../../utils/date';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
+import { Element, Undertittel } from 'nav-frontend-typografi';
+import { periodetekster, tekster } from '../../tekster';
 
-const Periode = withBehandlingContext(({ behandling }) => {
+const Periode = () => {
+    const { valgtBehandling } = useContext(BehandlingerContext);
     const {
         antallKalenderdager,
         arbeidsgiverperiodeKalenderdager,
@@ -18,10 +19,12 @@ const Periode = withBehandlingContext(({ behandling }) => {
         ferieperioder,
         antallUtbetalingsdager,
         sykmeldingsgrad
-    } = behandling.periode;
+    } = valgtBehandling.periode;
+
     const ferieperioderAsString = ferieperioder.map(
         periode => `${toDate(periode.fom)} - ${toDate(periode.tom)}`
     );
+
     return (
         <Panel className="Periode" border>
             <Undertittel className="panel-tittel">{periodetekster('tittel')}</Undertittel>
@@ -45,6 +48,6 @@ const Periode = withBehandlingContext(({ behandling }) => {
             <NavigationButtons previous="/beregning" next="/utbetaling" />
         </Panel>
     );
-});
+};
 
 export default Periode;

--- a/src/client/routes/Sykdomsvilkår/Sykdomsvilkår.jsx
+++ b/src/client/routes/Sykdomsvilkår/Sykdomsvilkår.jsx
@@ -1,29 +1,32 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import ListRow from '../../components/Rows/ListRow';
 import IconRow from '../../components/Rows/IconRow';
-import ListSeparator from '../../components/ListSeparator/ListSeparator';
-import Navigasjonsknapper from '../../components/NavigationButtons';
 import ItemMapper from '../../datamapping/sykdomsvilkårMapper';
+import ListSeparator from '../../components/ListSeparator';
+import Navigasjonsknapper from '../../components/NavigationButtons';
 import { Panel } from 'nav-frontend-paneler';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
 import { Element, Undertittel } from 'nav-frontend-typografi';
 import { sykdomsvilkårtekster, tekster } from '../../tekster';
-import { withBehandlingContext } from '../../context/BehandlingerContext';
 
-const Sykdomsvilkår = withBehandlingContext(({ behandling }) => (
-    <Panel className="Sykdomsvilkår" border>
-        <Undertittel className="panel-tittel">Sykdomsvilkår</Undertittel>
-        <IconRow label={sykdomsvilkårtekster('sykdomsvilkår_oppfylt')} bold />
-        <ListSeparator />
-        <Element className="mvp-tittel">{tekster('mvp')}</Element>
-        <ListRow
-            label={sykdomsvilkårtekster('mindre_enn_8_uker')}
-            items={ItemMapper.mindreEnnÅtteUker(
-                behandling.sykdomsvilkår.mindreEnnÅtteUkerSammenhengende
-            )}
-        />
-        <IconRow label={sykdomsvilkårtekster('ingen_yrkesskade')} bold />
-        <Navigasjonsknapper next="/inngangsvilkår" />
-    </Panel>
-));
+const Sykdomsvilkår = () => {
+    const { valgtBehandling } = useContext(BehandlingerContext);
+    return (
+        <Panel className="Sykdomsvilkår" border>
+            <Undertittel className="panel-tittel">Sykdomsvilkår</Undertittel>
+            <IconRow label={sykdomsvilkårtekster('sykdomsvilkår_oppfylt')} bold />
+            <ListSeparator />
+            <Element className="mvp-tittel">{tekster('mvp')}</Element>
+            <ListRow
+                label={sykdomsvilkårtekster('mindre_enn_8_uker')}
+                items={ItemMapper.mindreEnnÅtteUker(
+                    valgtBehandling.sykdomsvilkår.mindreEnnÅtteUkerSammenhengende
+                )}
+            />
+            <IconRow label={sykdomsvilkårtekster('ingen_yrkesskade')} bold />
+            <Navigasjonsknapper next="/inngangsvilkår" />
+        </Panel>
+    );
+};
 
 export default Sykdomsvilkår;

--- a/src/client/routes/Utbetaling/Utbetaling.jsx
+++ b/src/client/routes/Utbetaling/Utbetaling.jsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import IconRow from '../../components/Rows/IconRow';
 import FormRow from '../../components/Rows/FormRow';
 import ListSeparator from '../../components/ListSeparator/ListSeparator';
 import Navigasjonsknapper from '../../components/NavigationButtons';
 import { Panel } from 'nav-frontend-paneler';
-import { Element, Undertittel } from 'nav-frontend-typografi';
 import { toKroner } from '../../utils/locale';
-import { withBehandlingContext } from '../../context/BehandlingerContext';
+import { Element, Undertittel } from 'nav-frontend-typografi';
 import { tekster, utbetalingstekster } from '../../tekster';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
 
-const Utbetaling = withBehandlingContext(({ behandling }) => {
+const Utbetaling = () => {
+    const { valgtBehandling } = useContext(BehandlingerContext);
     const {
         antallUtbetalingsdager,
         betalerArbeidsgiverperiode,
@@ -17,7 +18,7 @@ const Utbetaling = withBehandlingContext(({ behandling }) => {
         sykepengegrunnlag,
         sykmeldingsgrad,
         utbetalingsbeløp
-    } = behandling.utbetaling;
+    } = valgtBehandling.utbetaling;
 
     return (
         <Panel className="Utbetaling" border>
@@ -64,6 +65,6 @@ const Utbetaling = withBehandlingContext(({ behandling }) => {
             <Navigasjonsknapper previous="/periode" next="/oppsummering" />
         </Panel>
     );
-});
+};
 
 export default Utbetaling;


### PR DESCRIPTION
`withBehandlingContext`-hocen er overflødig. Erstatter denne med kall til `useContext(BehandlingerContext)`.

Mange av endringene her er ikke "reelle" endringer, men indenteringsendringer trigget av prettier som et resultat av at vi ikke lenger wrapper komponentdeklarasjoner i `withBehandlingerContext()`.