### PR TITLE
Refactor context components

### DIFF
--- a/src/client/components/CaseMenu/CaseMenu.jsx
+++ b/src/client/components/CaseMenu/CaseMenu.jsx
@@ -6,14 +6,15 @@ import { toDate } from '../../utils/date';
 import { Normaltekst } from 'nav-frontend-typografi';
 import './CaseMenu.less';
 
+const behandlingMapper = behandling => ({
+    behandlingsId: behandling.behandlingsId,
+    fom: behandling.originalSøknad.fom,
+    tom: behandling.originalSøknad.tom
+});
+
 const CaseMenu = ({ behandlinger, behandling, onSelectItem }) => {
     const { arbeidsgiver, fom, tom } = behandling.originalSøknad;
     const { sykmeldingsgrad } = behandling.periode;
-    const behandlingMapper = behandling => ({
-        behandlingsId: behandling.behandlingsId,
-        fom: behandling.originalSøknad.fom,
-        tom: behandling.originalSøknad.tom
-    });
     const cases = behandlinger.map(behandling => behandlingMapper(behandling));
     const currentCase = behandlingMapper(behandling);
     const caseLabel = item => `${toDate(item.fom)} - ${toDate(item.tom)}`;

--- a/src/client/components/MainContentWrapper/MainContentWrapper.jsx
+++ b/src/client/components/MainContentWrapper/MainContentWrapper.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import PersonBar from '../PersonBar';
 import LeftMenu from '../LeftMenu';
 import Periode from '../../routes/Periode';
@@ -8,42 +8,19 @@ import Oppsummering from '../../routes/Oppsummering';
 import Sykdomsvilkår from '../../routes/Sykdomsvilkår';
 import Inngangsvilkår from '../../routes/Inngangsvilkår';
 import EmptyStateView from '../EmptyStateView';
-import VelgBehandlingModal from './VelgBehandlingModal';
 import { Route } from 'react-router-dom';
 import { BehandlingerContext } from '../../context/BehandlingerContext';
 import './MainContentWrapper.css';
 
 const MainContentWrapper = () => {
-    const { userMustSelectBehandling, velgBehandling, valgtBehandling, state } = useContext(
-        BehandlingerContext
-    );
-    const { behandlinger } = state;
-    const [modalOpen, setModalOpen] = useState(false);
-
-    useEffect(() => {
-        if (userMustSelectBehandling) {
-            setModalOpen(true);
-        }
-    }, [userMustSelectBehandling]);
-
-    const lukkModalOgVelgBehandling = valgtBehandling => {
-        setModalOpen(false);
-        velgBehandling(valgtBehandling);
-    };
+    const { velgBehandling, valgtBehandling, behandlinger } = useContext(BehandlingerContext);
 
     return (
         <div className="page-content">
-            {modalOpen && (
-                <VelgBehandlingModal
-                    setModalOpen={setModalOpen}
-                    behandlinger={behandlinger}
-                    onSelectItem={lukkModalOgVelgBehandling}
-                />
-            )}
             <LeftMenu
                 behandling={valgtBehandling}
                 behandlinger={behandlinger}
-                onSelectItem={lukkModalOgVelgBehandling}
+                onSelectItem={behandling => velgBehandling(behandling)}
             />
             {valgtBehandling ? (
                 <div className="main-content">

--- a/src/client/components/MainContentWrapper/MainContentWrapper.test.js
+++ b/src/client/components/MainContentWrapper/MainContentWrapper.test.js
@@ -1,27 +1,21 @@
 'use strict';
 
 import React from 'react';
-import { render, cleanup } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import MainContentWrapper from './MainContentWrapper';
-import ReactModal from 'react-modal';
 import { MemoryRouter } from 'react-router-dom';
+import { render, cleanup } from '@testing-library/react';
 import { BehandlingerContext } from '../../context/BehandlingerContext';
+import '@testing-library/jest-dom/extend-expect';
 
-ReactModal.setAppElement('*'); // suppresses modal-related test warnings.
 afterEach(cleanup);
 
-const behandling1 = {
-    behandlingsId: '123',
-    originalSøknad: { fom: '2019-05-10', tom: '2019-05-20' }
-};
+const behandlinger = [
+    { behandlingsId: '123', originalSøknad: { fom: '2019-05-10', tom: '2019-05-20' } },
+    { behandlingsId: '456', originalSøknad: { fom: '2019-06-10', tom: '2019-06-20' } }
+];
+
 const wrapperProps = {
-    state: {
-        behandlinger: [
-            behandling1,
-            { behandlingsId: '456', originalSøknad: { fom: '2019-06-10', tom: '2019-06-20' } }
-        ]
-    },
+    behandlinger: [...behandlinger],
     velgBehandling: jest.fn(),
     valgtBehandling: undefined
 };
@@ -29,54 +23,25 @@ const wrapperProps = {
 jest.mock('../PersonBar', () => () => <div />);
 jest.mock('../LeftMenu', () => () => <div />);
 
-jest.mock('nav-frontend-lukknapp-style', () => {
-    return {};
-});
-jest.mock('nav-frontend-modal-style', () => {
-    return {};
-});
-jest.mock('nav-frontend-typografi-style', () => {
-    return {};
-});
-jest.mock('nav-frontend-skjema-style', () => {
-    return {};
-});
-jest.mock('nav-frontend-knapper-style', () => {
-    return {};
-});
-jest.mock('nav-frontend-paneler-style', () => {
-    return {};
-});
-jest.mock('nav-frontend-chevron-style', () => {
-    return {};
-});
+jest.mock('nav-frontend-typografi-style', () => ({}));
+jest.mock('nav-frontend-lukknapp-style', () => ({}));
+jest.mock('nav-frontend-knapper-style', () => ({}));
+jest.mock('nav-frontend-paneler-style', () => ({}));
+jest.mock('nav-frontend-chevron-style', () => ({}));
+jest.mock('nav-frontend-skjema-style', () => ({}));
+jest.mock('nav-frontend-modal-style', () => ({}));
+
+jest.mock('nav-frontend-modal', () => ({
+    setAppElement: () => {}
+}));
 
 describe('MainContentWrapper', () => {
-    it('render modal when no behandling is chosen', () => {
-        const { getByText, container } = render(
-            <MemoryRouter>
-                <BehandlingerContext.Provider
-                    value={{
-                        ...wrapperProps,
-                        userMustSelectBehandling: true
-                    }}
-                >
-                    <MainContentWrapper />
-                </BehandlingerContext.Provider>
-            </MemoryRouter>
-        );
-        expect(
-            getByText('Denne brukeren har flere saker. Velg den saken du vil se på.')
-        ).toBeDefined();
-        expect(container.querySelector('.main-content')).toBe(null);
-    });
-
-    it('does not render modal when behandling is chosen', () => {
+    it('renders content when a behandling is selected', () => {
         const { container } = render(
             <BehandlingerContext.Provider
                 value={{
                     ...wrapperProps,
-                    valgtBehandling: { ...behandling1 }
+                    valgtBehandling: { ...behandlinger[0] }
                 }}
             >
                 <MainContentWrapper />
@@ -91,9 +56,7 @@ describe('MainContentWrapper', () => {
                 <BehandlingerContext.Provider
                     value={{
                         ...wrapperProps,
-                        state: {
-                            behandlinger: []
-                        }
+                        behandlinger: []
                     }}
                 >
                     <MainContentWrapper />

--- a/src/client/components/MainContentWrapper/VelgBehandlingModal.jsx
+++ b/src/client/components/MainContentWrapper/VelgBehandlingModal.jsx
@@ -8,8 +8,8 @@ import { toDate } from '../../utils/date';
 
 document && document.getElementById('#root') && Modal.setAppElement('#root');
 
-const VelgBehandlingModal = ({ setModalOpen, behandlinger, onSelectItem }) => (
-    <Modal onRequestClose={() => setModalOpen(false)} contentLabel="Velg behandling" isOpen={true}>
+const VelgBehandlingModal = ({ onRequestClose, behandlinger, onSelectItem }) => (
+    <Modal onRequestClose={onRequestClose} contentLabel="Velg behandling" isOpen={true}>
         <div className="VelgBehandlingModal">
             <Undertittel>Velg sak</Undertittel>
             <Normaltekst>Denne brukeren har flere saker. Velg den saken du vil se på.</Normaltekst>
@@ -33,7 +33,7 @@ const VelgBehandlingModal = ({ setModalOpen, behandlinger, onSelectItem }) => (
 VelgBehandlingModal.propTypes = {
     behandlinger: PropTypes.arrayOf(PropTypes.any).isRequired,
     onSelectItem: PropTypes.func.isRequired,
-    setModalOpen: PropTypes.func.isRequired
+    onRequestClose: PropTypes.func.isRequired
 };
 
 export default VelgBehandlingModal;

--- a/src/client/components/MainContentWrapper/VelgBehandlingModal.jsx
+++ b/src/client/components/MainContentWrapper/VelgBehandlingModal.jsx
@@ -1,12 +1,12 @@
 import Modal from 'nav-frontend-modal';
-import { Normaltekst, Element, Undertittel } from 'nav-frontend-typografi';
-import { Knapp } from 'nav-frontend-knapper';
 import React from 'react';
 import PropTypes from 'prop-types';
-import './VelgBehandlingModal.less';
+import { Knapp } from 'nav-frontend-knapper';
 import { toDate } from '../../utils/date';
+import { Normaltekst, Element, Undertittel } from 'nav-frontend-typografi';
+import './VelgBehandlingModal.less';
 
-document && document.getElementById('#root') && Modal.setAppElement('#root');
+Modal.setAppElement('#root');
 
 const VelgBehandlingModal = ({ onRequestClose, behandlinger, onSelectItem }) => (
     <Modal onRequestClose={onRequestClose} contentLabel="Velg behandling" isOpen={true}>

--- a/src/client/components/Search/Search.jsx
+++ b/src/client/components/Search/Search.jsx
@@ -1,17 +1,17 @@
 import React, { useContext, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router';
-import ErrorModal from '../ErrorModal';
-import { BehandlingerContext } from '../../context/BehandlingerContext';
-import { Keys } from '../../hooks/useKeyboard';
-import './Search.less';
-import { InnrapporteringContext } from '../../context/InnrapporteringContext';
 import SearchIcon from './SearchIcon';
+import ErrorModal from '../ErrorModal';
+import { Keys } from '../../hooks/useKeyboard';
+import { withRouter } from 'react-router';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
+import { InnrapporteringContext } from '../../context/InnrapporteringContext';
+import './Search.less';
 
 const Search = ({ history }) => {
-    const ref = useRef(undefined);
-    const behandlingerCtx = useContext(BehandlingerContext);
-    const innrapportering = useContext(InnrapporteringContext);
+    const ref = useRef();
+    const { fetchBehandlinger, setUserMustSelectBehandling } = useContext(BehandlingerContext);
+    const { resetUserFeedback } = useContext(InnrapporteringContext);
 
     const keyTyped = event => {
         const isEnter = (event.charCode || event.keyCode) === Keys.ENTER;
@@ -20,24 +20,23 @@ const Search = ({ history }) => {
         }
     };
 
-    const goBackToStart = newData => {
-        if (newData?.behandlinger && history.location.pathname !== '/sykdomsvilkår') {
+    const goBackToStart = behandlinger => {
+        if (behandlinger && history.location.pathname !== '/sykdomsvilkår') {
             history.push('/sykdomsvilkår');
         }
     };
 
     const search = async value => {
         if (value.trim().length !== 0) {
-            const data = await behandlingerCtx.fetchBehandlinger(value);
-
-            if (data?.behandlinger?.length > 0) {
-                innrapportering.setUenigheter([]);
-                innrapportering.setHasSendt(false);
-                innrapportering.setKommentarer('');
-                innrapportering.setGodkjent(true);
-            }
-
-            goBackToStart(data);
+            fetchBehandlinger(value).then(behandlinger => {
+                if (behandlinger?.length > 1) {
+                    setUserMustSelectBehandling(true);
+                }
+                if (behandlinger) {
+                    resetUserFeedback();
+                    goBackToStart(behandlinger);
+                }
+            });
         }
     };
 
@@ -47,16 +46,6 @@ const Search = ({ history }) => {
             <button onClick={() => search(ref.current.value)}>
                 <SearchIcon />
             </button>
-            {behandlingerCtx.error && (
-                <ErrorModal
-                    errorMessage={behandlingerCtx.error.message}
-                    onClose={
-                        behandlingerCtx.error.statusCode !== 401
-                            ? () => behandlingerCtx.clearError()
-                            : undefined
-                    }
-                />
-            )}
         </div>
     );
 };

--- a/src/client/components/Search/Search.jsx
+++ b/src/client/components/Search/Search.jsx
@@ -1,7 +1,6 @@
 import React, { useContext, useRef } from 'react';
 import PropTypes from 'prop-types';
 import SearchIcon from './SearchIcon';
-import ErrorModal from '../ErrorModal';
 import { Keys } from '../../hooks/useKeyboard';
 import { withRouter } from 'react-router';
 import { BehandlingerContext } from '../../context/BehandlingerContext';

--- a/src/client/context/BehandlingerContext.js
+++ b/src/client/context/BehandlingerContext.js
@@ -1,10 +1,10 @@
 import React, { createContext, useEffect, useState } from 'react';
+import moment from 'moment';
 import PropTypes from 'prop-types';
+import ErrorModal from '../components/ErrorModal';
+import VelgBehandlingModal from '../components/MainContentWrapper/VelgBehandlingModal';
 import { behandlingerFor, behandlingerIPeriode, getPerson } from '../io/http';
 import { useSessionStorage } from '../hooks/useSessionStorage';
-import moment from 'moment';
-import VelgBehandlingModal from '../components/MainContentWrapper/VelgBehandlingModal';
-import ErrorModal from '../components/ErrorModal';
 
 export const BehandlingerContext = createContext();
 

--- a/src/client/context/BehandlingerContext.js
+++ b/src/client/context/BehandlingerContext.js
@@ -3,134 +3,116 @@ import PropTypes from 'prop-types';
 import { behandlingerFor, behandlingerIPeriode, getPerson } from '../io/http';
 import { useSessionStorage } from '../hooks/useSessionStorage';
 import moment from 'moment';
+import VelgBehandlingModal from '../components/MainContentWrapper/VelgBehandlingModal';
+import ErrorModal from '../components/ErrorModal';
 
 export const BehandlingerContext = createContext();
+
+const appendPersoninfo = behandling => {
+    return getPerson(behandling.originalSøknad.aktorId)
+        .then(response => ({
+            ...behandling,
+            personinfo: {
+                navn: response.data?.navn,
+                kjønn: response.data?.kjønn,
+                fnr: response.data?.fnr
+            }
+        }))
+        .catch(err => {
+            console.error('Feil ved henting av person.', err);
+            return behandling;
+        });
+};
 
 export const BehandlingerProvider = ({ children }) => {
     const [error, setError] = useState(undefined);
     const [behandlinger, setBehandlinger] = useSessionStorage('behandlinger', []);
-    const [behandlingsoversikt, setBehandlingsoversikt] = useState([]);
-    const [valgtBehandling, setValgtBehandling] = useState(undefined);
-    const [lastSelectedBehandling, setLastSelectedBehandling] = useSessionStorage(
-        'last-selected-behandling-id',
-        undefined
+    const [valgtBehandling, setValgtBehandling] = useSessionStorage('valgtBehandling');
+    const [lastBehandlingId, setLastBehandlingId, didFetchLastBehandling] = useSessionStorage(
+        'lastBehandlingId'
     );
+    const [behandlingsoversikt, setBehandlingsoversikt] = useState([]);
     const [userMustSelectBehandling, setUserMustSelectBehandling] = useState(false);
 
-    const velgBehandlingFraOversikt = async ({ behandlingsId }) => {
-        const behandlingSummary = behandlingsoversikt.find(b => b.behandlingsId === behandlingsId);
-        if (behandlingSummary === undefined) {
-            setError({
-                message: 'En feil har oppstått. Vennligst prøv igjen eller kontakt systemansvarlig.'
-            });
-            return Promise.reject();
+    useEffect(() => {
+        fetchBehandlingsoversikt();
+    }, []);
+
+    useEffect(() => {
+        if (behandlinger?.length === 1) {
+            setValgtBehandling(behandlinger[0]);
         }
-        const behandlinger = await fetchBehandlinger(
-            behandlingSummary.originalSøknad.aktorId,
-            behandlingSummary.behandlingsId
+    }, [behandlinger]);
+
+    useEffect(() => {
+        if (valgtBehandling) {
+            setUserMustSelectBehandling(false);
+            setLastBehandlingId(valgtBehandling.behandlingsId);
+        }
+    }, [valgtBehandling]);
+
+    useEffect(() => {
+        if (!valgtBehandling && lastBehandlingId && didFetchLastBehandling) {
+            velgBehandling({ behandlingsId: lastBehandlingId });
+        }
+    }, [valgtBehandling, lastBehandlingId, didFetchLastBehandling]);
+
+    const velgBehandlingFraOversikt = ({ behandlingsId, originalSøknad }) => {
+        const cachedBehandling = behandlinger.find(b => b.behandlingsId === behandlingsId);
+        if (cachedBehandling) {
+            setValgtBehandling(cachedBehandling);
+            return Promise.resolve();
+        }
+
+        return fetchBehandlinger(originalSøknad.aktorId).then(behandlinger =>
+            setValgtBehandling(behandlinger.find(b => b.behandlingsId === behandlingsId))
         );
-        if (behandlinger === undefined) {
-            return Promise.reject();
-        }
-        setLastSelectedBehandling(behandlingsId);
     };
 
     const velgBehandling = ({ behandlingsId }) => {
-        const valgtBehandling = behandlinger.find(b => b.behandlingsId === behandlingsId);
-        setValgtBehandling(valgtBehandling);
-        setLastSelectedBehandling(valgtBehandling?.behandlingsId);
+        const behandling = behandlinger.find(b => b.behandlingsId === behandlingsId);
+        setValgtBehandling(behandling);
     };
 
-    useEffect(() => {
-        if (lastSelectedBehandling !== undefined && window.location.pathname !== '/') {
-            velgBehandling({ behandlingsId: lastSelectedBehandling });
-        }
-    }, [lastSelectedBehandling]);
-
-    const fetchBehandlingsoversiktMedPersoninfo = async () => {
+    const fetchBehandlingsoversikt = async () => {
         setValgtBehandling(undefined);
-        const alleBehandlinger = await fetchBehandlingsoversikt();
-        if (alleBehandlinger !== undefined) {
-            const behandlingerMedPersoninfo = await hentNavnForBehandlinger(alleBehandlinger);
-            if (behandlingerMedPersoninfo.find(behandling => behandling.personinfo === undefined)) {
-                setError({
-                    message: 'Kunne ikke hente navn for en eller flere saker. Viser aktørId'
-                });
-            }
-            setBehandlingsoversikt(behandlingerMedPersoninfo);
+        const oversikt = await fetchBehandlingsoversiktSinceYesterday();
+        const oversiktWithPersoninfo = await Promise.all(
+            oversikt.map(behandling => appendPersoninfo(behandling))
+        );
+        if (oversiktWithPersoninfo.find(behandling => behandling.personinfo === undefined)) {
+            setError({ message: 'Kunne ikke hente navn for en eller flere saker. Viser aktørId' });
         }
+        setBehandlingsoversikt(oversiktWithPersoninfo);
     };
 
-    const fetchBehandlingsoversikt = () => {
-        const fom = moment()
+    const fetchBehandlingsoversiktSinceYesterday = () => {
+        const yesterday = moment()
             .subtract(1, 'days')
             .format('YYYY-MM-DD');
-        const tom = moment().format('YYYY-MM-DD');
-        return behandlingerIPeriode(fom, tom)
-            .then(response => {
-                const newData = response.data;
-                return newData.behandlingsoversikt;
-            })
+        const today = moment().format('YYYY-MM-DD');
+        return behandlingerIPeriode(yesterday, today)
+            .then(response => response.data.behandlingsoversikt)
             .catch(err => {
-                if (err.statusCode === 401) {
-                    setError({ ...err, message: 'Du må logge inn på nytt.' });
-                } else if (err.statusCode === 404) {
-                    setError({
-                        ...err,
-                        message: `Fant ingen behandlinger mellom i går og i dag.`
-                    });
-                } else {
-                    setError({
-                        ...err,
-                        message: 'Kunne ikke hente behandlinger. Prøv igjen senere.'
-                    });
-                }
-                console.error('Feil ved henting av behandlinger. ', err);
+                setError({
+                    ...err,
+                    message:
+                        err.statusCode === 401
+                            ? 'Du må logge inn på nytt'
+                            : err.statusCode === 404
+                            ? 'Fant ingen behandlinger mellom i går og i dag.'
+                            : 'Kunne ikke hente behandlinger. Prøv igjen senere.'
+                });
                 return [];
             });
     };
 
-    const hentNavnForBehandlinger = async alleBehandlinger => {
-        return await Promise.all(alleBehandlinger.map(behandling => fetchPerson(behandling)));
-    };
-
-    const fetchPerson = behandling => {
-        return getPerson(behandling.originalSøknad.aktorId)
-            .then(response => ({
-                ...behandling,
-                personinfo: {
-                    navn: response.data?.navn,
-                    kjønn: response.data?.kjønn,
-                    fnr: response.data?.fnr
-                }
-            }))
-            .catch(err => {
-                console.error('Feil ved henting av person.', err);
-                return behandling;
-            });
-    };
-
-    const fetchBehandlinger = (value, behandlingsId) => {
-        setUserMustSelectBehandling(false);
+    const fetchBehandlinger = value => {
         return behandlingerFor(value)
             .then(response => {
                 const { behandlinger } = response.data;
                 setBehandlinger(behandlinger);
-                if (!behandlingsId) {
-                    if (behandlinger?.length === 1) {
-                        setLastSelectedBehandling(behandlinger[0].behandlingsId);
-                    } else if (behandlinger.length > 1) {
-                        setLastSelectedBehandling(null);
-                        setUserMustSelectBehandling(true);
-                    }
-
-                    setValgtBehandling(behandlinger?.length !== 1 ? undefined : behandlinger[0]);
-                } else {
-                    setValgtBehandling(
-                        behandlinger.find(behandling => behandling.behandlingsId === behandlingsId)
-                    );
-                }
-                return { behandlinger };
+                return behandlinger;
             })
             .catch(err => {
                 const message =
@@ -146,19 +128,29 @@ export const BehandlingerProvider = ({ children }) => {
     return (
         <BehandlingerContext.Provider
             value={{
-                state: { behandlinger },
-                behandlingsoversikt,
+                behandlinger,
                 velgBehandling,
                 velgBehandlingFraOversikt,
+                behandlingsoversikt,
                 valgtBehandling,
                 fetchBehandlinger,
-                userMustSelectBehandling,
-                fetchBehandlingsoversiktMedPersoninfo,
-                error,
-                clearError: () => setError(undefined)
+                setUserMustSelectBehandling
             }}
         >
             {children}
+            {error && (
+                <ErrorModal
+                    errorMessage={error.message}
+                    onClose={error.statusCode !== 401 ? () => setError(undefined) : undefined}
+                />
+            )}
+            {userMustSelectBehandling && (
+                <VelgBehandlingModal
+                    onRequestClose={() => setUserMustSelectBehandling(false)}
+                    behandlinger={behandlinger}
+                    onSelectItem={behandling => velgBehandling(behandling)}
+                />
+            )}
         </BehandlingerContext.Provider>
     );
 };

--- a/src/client/hooks/useSessionStorage.js
+++ b/src/client/hooks/useSessionStorage.js
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
  */
 export const useSessionStorage = (key, initialValue) => {
     const [state, setState] = useState(initialValue);
+    const [didFetchFromStorage, setDidFetchFromStorage] = useState(false);
 
     useEffect(() => {
         if (state !== undefined && state !== initialValue) {
@@ -16,17 +17,16 @@ export const useSessionStorage = (key, initialValue) => {
 
     useEffect(() => {
         const sessionState = sessionStorage.getItem(key);
-        if (!keyExistsInSessionStorage(sessionState)) return;
-
-        const parsedState = parseData(sessionState);
-        if (parsedState !== undefined) {
-            setState(parsedState);
-        } else {
-            sessionStorage.removeItem(key);
+        if (sessionState !== null) {
+            const parsedState = parseData(sessionState);
+            if (parsedState !== undefined) {
+                setState(parsedState);
+            } else {
+                sessionStorage.removeItem(key);
+            }
         }
+        setDidFetchFromStorage(true);
     }, [key]);
-
-    const keyExistsInSessionStorage = key => key !== null;
 
     const parseData = data => {
         try {
@@ -36,5 +36,5 @@ export const useSessionStorage = (key, initialValue) => {
         }
     };
 
-    return [state, setState];
+    return [state, setState, didFetchFromStorage];
 };

--- a/src/client/routes/Oversikt/Oversikt.jsx
+++ b/src/client/routes/Oversikt/Oversikt.jsx
@@ -1,62 +1,52 @@
-import React, { useContext, useEffect, useMemo } from 'react';
-import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
-import { Panel } from 'nav-frontend-paneler';
-import { withRouter } from 'react-router';
+import React, { useContext, useMemo } from 'react';
 import Lenke from 'nav-frontend-lenker';
 import PropTypes from 'prop-types';
-import { BehandlingerContext } from '../../context/BehandlingerContext';
-import { InnrapporteringContext } from '../../context/InnrapporteringContext';
-import { extractNameFromEmail } from '../../utils/locale';
+import { Panel } from 'nav-frontend-paneler';
+import { withRouter } from 'react-router';
 import { oversikttekster } from '../../tekster';
+import { BehandlingerContext } from '../../context/BehandlingerContext';
+import { extractNameFromEmail } from '../../utils/locale';
 import { toDate, toDateAndTime } from '../../utils/date';
+import { InnrapporteringContext } from '../../context/InnrapporteringContext';
+import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
 import './Oversikt.less';
 
+const toBehandletSak = (behandling, feedback) => ({
+    ...behandling,
+    søkerName: behandling.personinfo?.navn ?? behandling.originalSøknad.aktorId,
+    submittedDate: feedback.value.submittedDate,
+    behandlingsId: behandling.behandlingsId,
+    userName: extractNameFromEmail(feedback.value.userId.email)
+});
+
 const Oversikt = ({ history }) => {
-    const {
-        behandlingsoversikt,
-        fetchBehandlingsoversiktMedPersoninfo,
-        velgBehandlingFraOversikt
-    } = useContext(BehandlingerContext);
-    const innrapportering = useContext(InnrapporteringContext);
-
-    useEffect(() => {
-        fetchBehandlingsoversiktMedPersoninfo();
-    }, []);
-
-    const toBehandletSak = (behandling, feedback) => ({
-        søkerName: behandling.personinfo?.navn ?? behandling.originalSøknad.aktorId,
-        submittedDate: feedback.value.submittedDate,
-        behandlingsId: behandling.behandlingsId,
-        userName: extractNameFromEmail(feedback.value.userId.email)
-    });
+    const { behandlingsoversikt, velgBehandlingFraOversikt } = useContext(BehandlingerContext);
+    const { feedback } = useContext(InnrapporteringContext);
 
     const [behandledeSaker, ubehandledeSaker] = useMemo(
         () =>
             behandlingsoversikt.reduce(
-                ([behandledeSaker, ubehandledeSaker], behandling) => {
-                    const feedback = innrapportering.feedback.find(
+                (partitioned, behandling) => {
+                    const feedbackForBehandling = feedback.find(
                         f => f.key === behandling.behandlingsId
                     );
-                    return feedback
+                    return feedbackForBehandling
                         ? [
-                              [...behandledeSaker, toBehandletSak(behandling, feedback)],
-                              ubehandledeSaker
+                              [
+                                  ...partitioned[0],
+                                  toBehandletSak(behandling, feedbackForBehandling)
+                              ],
+                              partitioned[1]
                           ]
-                        : [behandledeSaker, [...ubehandledeSaker, behandling]];
+                        : [partitioned[0], [...partitioned[1], behandling]];
                 },
                 [[], []]
             ),
-        [innrapportering.feedback, behandlingsoversikt]
+        [feedback, behandlingsoversikt]
     );
 
-    const velgBehandlingAndNavigate = async behandling => {
-        await velgBehandlingFraOversikt(behandling)
-            .then(() => {
-                history.push('/sykdomsvilkår');
-            })
-            .catch(() => {
-                // Catch rejection to avoid warning; expecting error handling to have been done
-            });
+    const velgBehandlingAndNavigate = behandling => {
+        velgBehandlingFraOversikt(behandling).then(() => history.push('/sykdomsvilkår'));
     };
 
     return (
@@ -113,10 +103,7 @@ const Oversikt = ({ history }) => {
 
 Oversikt.propTypes = {
     history: PropTypes.shape({
-        push: PropTypes.func.isRequired,
-        location: PropTypes.shape({
-            pathname: PropTypes.string.isRequired
-        }).isRequired
+        push: PropTypes.func.isRequired
     }).isRequired
 };
 


### PR DESCRIPTION
Skriver om contextproviderne BehandlingerProvider og InnrapporteringProvider ved å bryte opp lange funksjoner og bruke mer beskrivende navn for variabler og funksjoner. Bruker heller `useEffect` for å synkronisere hendelser/endringer i state fremfor å ha lange funksjoner som gjør veldig mye.

Fikset også en bug hvor `feedback` i noen tilfeller ikke fetches.