### PR TITLE
Disable rule that might destroy our code on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
             "git add"
         ],
         "*.{js,jsx}": [
-            "eslint --fix",
+            "eslint --fix --rule react-hooks/exhaustive-deps:off",
             "git add"
         ]
     },


### PR DESCRIPTION
The exhaustive-deps rule in combination with the autofix functionality
of eslint (which we run on commit) can insert dependencies in our
effects. While this is due to our code not following React best
practices, our code works, and after the autofixing it may stop working.

Discussion of the plugin shortcomings:
https://github.com/facebook/react/issues/15204#issuecomment-476789202