### PR TITLE
Hent data til oversikt bare når man laster oversiktssiden

### DIFF
--- a/src/client/context/BehandlingerContext.js
+++ b/src/client/context/BehandlingerContext.js
@@ -24,20 +24,10 @@ const appendPersoninfo = behandling => {
 
 export const BehandlingerProvider = ({ children }) => {
     const [error, setError] = useState(undefined);
-    const [personTilBehandling, setPersonTilBehandling] = useSessionStorage('person', {});
+    const [personTilBehandling, setPersonTilBehandling] = useSessionStorage('person');
     const [behandlingsoversikt, setBehandlingsoversikt] = useState([]);
     const [isFetchingBehandlingsoversikt, setIsFetchingBehandlingsoversikt] = useState(false);
     const [isFetchingPersoninfo, setIsFetchingPersoninfo] = useState(false);
-
-    useEffect(() => {
-        fetchBehandlingsoversikt();
-    }, []);
-
-    useEffect(() => {
-        if (personTilBehandling !== undefined) {
-            setPersonTilBehandling(personTilBehandling);
-        }
-    }, [personTilBehandling]);
 
     const velgBehandlingFraOversikt = ({ aktørId }) => {
         return hentPerson(aktørId);
@@ -99,6 +89,7 @@ export const BehandlingerProvider = ({ children }) => {
             value={{
                 velgBehandlingFraOversikt,
                 behandlingsoversikt,
+                fetchBehandlingsoversikt,
                 personTilBehandling,
                 hentPerson,
                 isFetchingBehandlingsoversikt,

--- a/src/client/routes/Oversikt/Oversikt.jsx
+++ b/src/client/routes/Oversikt/Oversikt.jsx
@@ -34,6 +34,7 @@ const partition = predicate => (acc, cur) =>
 const Oversikt = ({ history }) => {
     const {
         behandlingsoversikt,
+        fetchBehandlingsoversikt,
         velgBehandlingFraOversikt,
         isFetchingBehandlingsoversikt,
         isFetchingPersoninfo
@@ -57,6 +58,10 @@ const Oversikt = ({ history }) => {
                 .reduce(partition(b => b.behandlet), [[], []]),
         [feedback, behandlingsoversikt]
     );
+
+    useEffect(() => {
+        fetchBehandlingsoversikt();
+    }, []);
 
     useEffect(() => {
         fetchTildelinger();


### PR DESCRIPTION
Dette fikser en bug som gjorde at person hentet fra sessionStorage ble
overskrevet med undefined ved sidelast og hot reloading.