### PR TITLE
Opprett tildelinger context

### DIFF
--- a/src/client/components/App.jsx
+++ b/src/client/components/App.jsx
@@ -8,11 +8,12 @@ import { AuthProvider } from '../context/AuthContext';
 import { BrowserRouter } from 'react-router-dom';
 import { Route, Switch } from 'react-router-dom';
 import { useLogUserOut } from '../hooks/useLogUserOut';
+import { TildelingerProvider } from '../context/TildelingerContext';
 import { withContextProviders } from '../context/withContextProviders';
-import { InnrapporteringProvider } from '../context/InnrapporteringContext';
-import { EasterEggProvider, EasterEggContext } from '../context/EasterEggContext';
-import { PersonContext, PersonProvider } from '../context/PersonContext';
 import { PersonoversiktProvider } from '../context/PersonoversiktContext';
+import { InnrapporteringProvider } from '../context/InnrapporteringContext';
+import { PersonContext, PersonProvider } from '../context/PersonContext';
+import { EasterEggProvider, EasterEggContext } from '../context/EasterEggContext';
 import './App.less';
 import 'reset-css';
 
@@ -40,7 +41,8 @@ const App = withContextProviders(() => {
     PersonoversiktProvider,
     PersonProvider,
     AuthProvider,
-    EasterEggProvider
+    EasterEggProvider,
+    TildelingerProvider
 ]);
 
 export default App;

--- a/src/client/context/TildelingerContext.jsx
+++ b/src/client/context/TildelingerContext.jsx
@@ -1,0 +1,73 @@
+import React, { createContext, useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
+import { deleteTildeling, getTildelinger, postTildeling } from '../io/http';
+
+export const TildelingerContext = createContext({});
+
+export const TildelingerProvider = ({ children }) => {
+    const [tildelinger, setTildelinger] = useState([]);
+    const [error, setError] = useState();
+
+    const tildelBehandling = useCallback((behandlingsId, userId) => {
+        postTildeling({ behandlingsId, userId })
+            .then(() => {
+                setTildelinger(t => [...t, { behandlingsId, userId }]);
+                setError(undefined);
+            })
+            .catch(error => {
+                const assignedUser = error.message?.alreadyAssignedTo;
+                if (assignedUser) {
+                    setError(`Saken er allerede tildelt til ${assignedUser}`);
+                } else {
+                    setError('Kunne ikke tildele sak.');
+                }
+            });
+    }, []);
+
+    const fetchTildelinger = useCallback(personoversikt => {
+        if (personoversikt.length > 0) {
+            const behandlingsIdList = personoversikt.map(b => b.behandlingsId);
+            getTildelinger(behandlingsIdList)
+                .then(result => {
+                    const nyeTildelinger = result.data.filter(
+                        behandlingId => behandlingId.userId !== undefined
+                    );
+                    setTildelinger(nyeTildelinger);
+                })
+                .catch(err => {
+                    setError('Kunne ikke hente tildelingsinformasjon.');
+                    console.error(err);
+                });
+        }
+    }, []);
+
+    const fjernTildeling = useCallback(behandlingsId => {
+        deleteTildeling(behandlingsId)
+            .then(() => {
+                setTildelinger(tildelinger.filter(t => t.behandlingsId !== behandlingsId));
+                setError(undefined);
+            })
+            .catch(error => {
+                setError('Kunne ikke fjerne tildeling av sak.');
+                console.error(error);
+            });
+    }, []);
+
+    return (
+        <TildelingerContext.Provider
+            value={{
+                tildelinger,
+                tildelBehandling,
+                tildelingError: error,
+                fetchTildelinger,
+                fjernTildeling
+            }}
+        >
+            {children}
+        </TildelingerContext.Provider>
+    );
+};
+
+TildelingerProvider.propTypes = {
+    children: PropTypes.node
+};

--- a/src/client/routes/Oversikt/Oversikt.jsx
+++ b/src/client/routes/Oversikt/Oversikt.jsx
@@ -1,19 +1,18 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Oversiktslinje from './Oversiktslinje';
 import OversiktsLenke from './OversiktsLenke';
 import NavFrontendSpinner from 'nav-frontend-spinner';
 import { Panel } from 'nav-frontend-paneler';
 import { withRouter } from 'react-router';
-import { AuthContext } from '../../context/AuthContext';
 import { toDateAndTime } from '../../utils/date';
 import { oversikttekster } from '../../tekster';
-import { AlertStripeAdvarsel, AlertStripeInfo } from 'nav-frontend-alertstriper';
+import { TildelingerContext } from '../../context/TildelingerContext';
 import { PersonoversiktContext } from '../../context/PersonoversiktContext';
 import { InnrapporteringContext } from '../../context/InnrapporteringContext';
 import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
+import { AlertStripeAdvarsel, AlertStripeInfo } from 'nav-frontend-alertstriper';
 import { capitalizeName, extractNameFromEmail } from '../../utils/locale';
-import { deleteTildeling, getTildelinger, postTildeling } from '../../io/http';
 import 'nav-frontend-lenker-style';
 import './Oversikt.less';
 
@@ -39,10 +38,14 @@ const Oversikt = ({ history }) => {
         isFetchingPersonoversikt,
         isFetchingPersoninfo
     } = useContext(PersonoversiktContext);
+    const {
+        tildelBehandling,
+        tildelinger,
+        tildelingError,
+        fetchTildelinger,
+        fjernTildeling
+    } = useContext(TildelingerContext);
     const { feedback } = useContext(InnrapporteringContext);
-    const { authInfo } = useContext(AuthContext);
-    const [tildelinger, setTildelinger] = useState([]);
-    const [error, setError] = useState();
 
     const [behandledeSaker, ubehandledeSaker] = useMemo(
         () =>
@@ -64,58 +67,13 @@ const Oversikt = ({ history }) => {
     }, []);
 
     useEffect(() => {
-        fetchTildelinger();
-        const interval = window.setInterval(fetchTildelinger, FETCH_TILDELINGER_INTERVAL_IN_MS);
-        return () => {
-            window.clearInterval(interval);
-        };
+        fetchTildelinger(personoversikt);
+        const id = window.setInterval(
+            () => fetchTildelinger(personoversikt),
+            FETCH_TILDELINGER_INTERVAL_IN_MS
+        );
+        return () => window.clearInterval(id);
     }, [personoversikt.length]);
-
-    const fetchTildelinger = () => {
-        if (personoversikt.length > 0) {
-            const behandlingsIdList = personoversikt.map(b => b.behandlingsId);
-            getTildelinger(behandlingsIdList)
-                .then(result => {
-                    const nyeTildelinger = result.data.filter(
-                        behandlingId => behandlingId.userId !== undefined
-                    );
-                    setTildelinger(nyeTildelinger);
-                })
-                .catch(err => {
-                    setError('Kunne ikke hente tildelingsinformasjon.');
-                    console.error(err);
-                });
-        }
-    };
-
-    const tildelBehandling = behandlingsId => {
-        const userId = authInfo.email;
-        postTildeling({ behandlingsId, userId })
-            .then(() => {
-                setTildelinger([...tildelinger, { behandlingsId, userId }]);
-                setError(undefined);
-            })
-            .catch(error => {
-                const assignedUser = error.message?.alreadyAssignedTo;
-                if (assignedUser) {
-                    setError(`Saken er allerede tildelt til ${assignedUser}`);
-                } else {
-                    setError('Kunne ikke tildele sak.');
-                }
-            });
-    };
-
-    const fjernTildeling = behandlingsId => {
-        deleteTildeling(behandlingsId)
-            .then(() => {
-                setTildelinger(tildelinger.filter(t => t.behandlingsId !== behandlingsId));
-                setError(undefined);
-            })
-            .catch(error => {
-                setError('Kunne ikke fjerne tildeling av sak.');
-                console.error(error);
-            });
-    };
 
     const velgBehandlingAndNavigate = behandling => {
         velgPersonFraOversikt(behandling).then(() => history.push('/sykdomsvilkår'));
@@ -123,7 +81,7 @@ const Oversikt = ({ history }) => {
 
     return (
         <div className="Oversikt">
-            {error && <AlertStripeAdvarsel>{error}</AlertStripeAdvarsel>}
+            {tildelingError && <AlertStripeAdvarsel>{tildelingError}</AlertStripeAdvarsel>}
             <div className="Oversikt__container">
                 <Panel border className="Oversikt__neste-behandlinger">
                     <Undertittel className="panel-tittel">{oversikttekster('tittel')}</Undertittel>

--- a/src/client/routes/Oversikt/Oversiktslinje.jsx
+++ b/src/client/routes/Oversikt/Oversiktslinje.jsx
@@ -23,7 +23,7 @@ const Oversiktslinje = ({ behandling, tildeling, onUnassignCase, onAssignCase, o
             )}
         </>
     ) : (
-        <Knapp mini onClick={() => onAssignCase(behandling.behandlingsId)}>
+        <Knapp mini onClick={() => onAssignCase(behandling.behandlingsId, authInfo.email)}>
             Tildel til meg
         </Knapp>
     );


### PR DESCRIPTION
Det er behov for tildelingsinfo andre steder i speil enn bare i oversiktsbildet. Henter ut lokal tildelings-state fra Oversikt og legger dette i en egen context, TildelingerContext.