### PR TITLE
Fikser to bugs med keyboard-navigering

### DIFF
--- a/src/client/components/NavigationButtons/NavigationButtons.jsx
+++ b/src/client/components/NavigationButtons/NavigationButtons.jsx
@@ -11,16 +11,16 @@ const tooltip = (direction = 'right') =>
 
 const NavigationButtons = ({ history, previous, next }) => {
     const clickPrevious = () => {
-        history.push(previous);
+        previous && history.push(previous);
     };
 
     const clickNext = () => {
-        history.push(next);
+        next && history.push(next);
     };
 
     useKeyboard([
-        { keyCode: Keys.LEFT, action: clickPrevious },
-        { keyCode: Keys.RIGHT, action: clickNext }
+        { keyCode: Keys.LEFT, action: clickPrevious, ignoreIfModifiers: true },
+        { keyCode: Keys.RIGHT, action: clickNext, ignoreIfModifiers: true }
     ]);
 
     return (

--- a/src/client/hooks/useKeyboard.js
+++ b/src/client/hooks/useKeyboard.js
@@ -18,16 +18,25 @@ export const useKeyboard = actionMappings => {
     const [map, setMap] = useState({});
 
     const handleKeyDown = e => {
-        if (!shouldDisableKeyboard()) {
-            map[e.keyCode]?.();
+        const keyConfig = map[e.keyCode];
+        if (!keyConfig || shouldDisableKeyboard()) return;
+
+        if (
+            keyConfig.ignoreIfModifiers &&
+            (e.getModifierState('Meta') || e.getModifierState('Alt'))
+        ) {
+            return;
         }
+        map[e.keyCode]?.action();
     };
 
     useEffect(() => {
         actionMappings.forEach(mapping => {
             setMap(map => ({
                 ...map,
-                [mapping.keyCode]: mapping.action
+                [mapping.keyCode]: {
+                    ...mapping
+                }
             }));
         });
     }, []);


### PR DESCRIPTION
Kunne ikke bruke keyboard shortcut for å navigere frem eller tilbake i
history hvis man var på en side med NavigationButtons, da "Meta + Pil
venstre" ble fanget opp som "Pil venstre" av useKeyboard.

Det ble gjort en `history.push(undefined)` hvis man trykket pil høyre på
oppsummeringssiden eller pil venstre på sykmeldingsperiode-siden, som
gjorde bakovernavigering i nettleserhistorikken forvirrende.