### PR TITLE
Full bredde på varsel om 'sendt til oppdrag'

### DIFF
--- a/packages/frontend/components/Varsler.tsx
+++ b/packages/frontend/components/Varsler.tsx
@@ -20,6 +20,7 @@ const Container = styled.div`
 const EphemeralContainer = styled.div`
     position: absolute;
     overflow-y: hidden;
+    width: 100vw;
 `;
 
 const TechnicalVarsel = ({ type, message, technical }: VarselObject) => (


### PR DESCRIPTION
Vi fjernet vel `100vw` for å få fjernet en scrollbar nederst i skjermbildet, og det funka (https://github.com/navikt/helse-speil/commit/a65bd6983fb1087a84ae32c65637cb36443f33d1). Samtidig gjorde vi at varselet når man har godkjent noe bare fikk bredde etter innholdet og så rart ut (det er et ephemeral varsel).

Denne endringen ser ikke ut til å ødelegge noe. På den andre siden klarer jeg ikke å gjenskape problemet for ikke-ephemeral varsler.